### PR TITLE
Edit posts

### DIFF
--- a/flutter/wtc/lib/pages/edit_event.dart
+++ b/flutter/wtc/lib/pages/edit_event.dart
@@ -1,0 +1,317 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter_guid/flutter_guid.dart';
+import 'package:wtc/widgets/event_widgets/event.dart';
+
+class EditPostEventPage extends StatefulWidget {
+  const EditPostEventPage({super.key, required this.post});
+
+  final Event post;
+
+  @override
+  State<EditPostEventPage> createState() => _EditPostEventPageState();
+}
+
+class _EditPostEventPageState extends State<EditPostEventPage> {
+  // Text editing controllers to capture input from text fields
+  final TextEditingController _titleController = TextEditingController();
+  final TextEditingController _headerController = TextEditingController();
+  final TextEditingController _descriptionController = TextEditingController();
+  final TextEditingController _addressController = TextEditingController();
+  final TextEditingController _dateController = TextEditingController();
+  final TextEditingController _timeController = TextEditingController();
+
+  Map<String, bool> tags = {
+    'Eastern': false,
+    'Traffic': false,
+    'Accident': false,
+    'Weather': false,
+    'Construction': false,
+    'Event': false,
+  };
+
+  @override
+  void initState() {
+    super.initState();
+    _titleController.text = widget.post.title;
+    _headerController.text = widget.post.header;
+    _descriptionController.text = widget.post.body;
+    _addressController.text = widget.post.location;
+    _dateController.text =
+        '${widget.post.date.year}-${widget.post.date.month}-${widget.post.date.day}';
+    _timeController.text = _formatTimeOfDay(widget.post.time);
+    for (String tag in widget.post.tags) {
+      if (tags[tag] != null) {
+        tags[tag] = true;
+      }
+    }
+  }
+
+  String _formatTimeOfDay(TimeOfDay time) {
+    final hour = time.hour;
+    final minute = time.minute;
+    String formattedMinute = minute < 10 ? '0$minute' : minute.toString();
+    String period = hour >= 12 ? 'PM' : 'AM';
+    String formattedHour = hour == 0
+        ? '12'
+        : hour > 12
+            ? (hour - 12).toString()
+            : hour.toString();
+
+    return '$formattedHour:$formattedMinute $period';
+  }
+
+  @override
+  void dispose() {
+    // Dispose controllers when the widget is removed from the widget tree
+    _titleController.dispose();
+    _descriptionController.dispose();
+    _addressController.dispose();
+    _dateController.dispose();
+    _timeController.dispose();
+    super.dispose();
+  }
+
+  void showTags() {
+    showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: const Text('Select Tags'),
+          content: StatefulBuilder(
+            builder: (BuildContext context, StateSetter setState) {
+              return Column(
+                mainAxisSize: MainAxisSize.min,
+                children: tags.keys.map((String tag) {
+                  return CheckboxListTile(
+                    title: Text(tag),
+                    value: tags[tag],
+                    onChanged: (bool? value) {
+                      setState(() {
+                        // Update the selection state of the tag
+                        tags[tag] = value!;
+                      });
+                    },
+                  );
+                }).toList(),
+              );
+            },
+          ),
+          actions: <Widget>[
+            TextButton(
+              onPressed: () {
+                Navigator.of(context).pop();
+              },
+              child: const Text('Done'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  Future<void> _updateEvent() async {
+    // Check if any of the required fields are empty
+    if (_titleController.text.isEmpty ||
+        _descriptionController.text.isEmpty ||
+        _addressController.text.isEmpty ||
+        _dateController.text.isEmpty ||
+        _timeController.text.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Please fill all required fields')),
+      );
+      return; // Exit the function if validation fails
+    }
+
+    // Check if the text fields have at least 4 characters
+    if (_titleController.text.length < 4 ||
+        _descriptionController.text.length < 4 ||
+        _headerController.text.length < 4) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+            content: Text('Each field must have at least 4 characters')),
+      );
+      return; // Exit the function if validation fails
+    }
+
+    if (_titleController.text.length > 60 ||
+        _headerController.text.length > 60) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+            content: Text(
+                'Title or quick description can have no more than 60 characters.')),
+      );
+      return; // Exit the function if validation fails
+    }
+
+    // Validate date format using a try-catch to catch any parsing errors
+    try {
+      final date = DateFormat('yyyy-MM-dd').parseStrict(_dateController.text);
+    } catch (e) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Invalid date format')),
+      );
+      return; // Exit if the date format is incorrect
+    }
+
+    // Validate time format
+    final timeParts = _timeController.text.split(':');
+    if (timeParts.length != 2 ||
+        !timeParts[0].isNotEmpty ||
+        !timeParts[1].isNotEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Invalid time format')),
+      );
+      return; // Exit if the time format is incorrect
+    }
+
+    // Check if at least one tag is selected
+    bool anyTagSelected = tags.values.any((bool isSelected) => isSelected);
+    if (!anyTagSelected) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Please select at least one tag')),
+      );
+      return; // Exit if no tags are selected
+    }
+
+    var convertedTags = [];
+    for (String key in tags.keys) {
+      if (tags[key] == true) {
+        convertedTags.add(key);
+      }
+    }
+
+    await FirebaseFirestore.instance
+        .collection('_posts')
+        .doc(widget.post.postId.toString())
+        .update({
+      'body': _descriptionController.text,
+      'header': _headerController.text,
+      'tags': convertedTags,
+      'title': _titleController.text,
+      'address': _addressController.text,
+      'eventDate': _dateController.text,
+      'eventTime': _timeController.text,
+    });
+
+    // Clear the fields
+    _titleController.clear();
+    _headerController.clear();
+    _descriptionController.clear();
+    _addressController.clear();
+    _dateController.clear();
+    _timeController.clear();
+
+    // Show a snackbar as feedback
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Post submitted successfully')),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Create Event'),
+      ),
+      body: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Column(
+            children: [
+              TextField(
+                controller: _titleController,
+                decoration: const InputDecoration(
+                  labelText: 'Title',
+                ),
+              ),
+              const SizedBox(height: 16.0),
+              TextField(
+                controller: _headerController,
+                decoration: const InputDecoration(
+                  labelText: 'Quick description',
+                ),
+                minLines: 1,
+                maxLines: 2,
+              ),
+              const SizedBox(height: 16.0),
+              TextField(
+                controller: _descriptionController,
+                decoration: const InputDecoration(
+                  labelText: 'Description',
+                ),
+                minLines: 1,
+                maxLines: 5,
+              ),
+              const SizedBox(height: 16.0),
+              TextField(
+                controller: _addressController,
+                decoration: const InputDecoration(
+                  labelText: 'Address',
+                ),
+              ),
+              const SizedBox(height: 16.0),
+              TextField(
+                controller: _dateController,
+                decoration: const InputDecoration(
+                  labelText: 'Date',
+                  hintText: 'YYYY-MM-DD',
+                ),
+                keyboardType: TextInputType.datetime,
+                onTap: () async {
+                  FocusScope.of(context).requestFocus(
+                      new FocusNode()); // to prevent keyboard from appearing
+                  DateTime? picked = await showDatePicker(
+                    context: context,
+                    initialDate: DateTime.now(),
+                    firstDate: DateTime.now(),
+                    lastDate: DateTime(2100),
+                  );
+                  if (picked != null) {
+                    _dateController.text =
+                        DateFormat('yyyy-MM-dd').format(picked);
+                  }
+                },
+              ),
+              const SizedBox(height: 16.0),
+              TextField(
+                controller: _timeController,
+                decoration: const InputDecoration(
+                  labelText: 'Time',
+                  hintText: 'HH:MM',
+                ),
+                keyboardType: TextInputType.datetime,
+                onTap: () async {
+                  FocusScope.of(context).requestFocus(
+                      new FocusNode()); // to prevent keyboard from appearing
+                  TimeOfDay? picked = await showTimePicker(
+                    context: context,
+                    initialTime: TimeOfDay.now(),
+                  );
+                  if (picked != null) {
+                    _timeController.text = picked.format(context);
+                  }
+                },
+              ),
+              const SizedBox(height: 16.0),
+              ElevatedButton(
+                onPressed: showTags,
+                child: const Text('Select Tags'),
+              ),
+              const SizedBox(height: 32.0),
+              ElevatedButton(
+                onPressed: () async {
+                  await _updateEvent();
+                  Navigator.pop(context);
+                },
+                child: const Text('Submit'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/flutter/wtc/lib/pages/edit_event.dart
+++ b/flutter/wtc/lib/pages/edit_event.dart
@@ -306,7 +306,7 @@ class _EditPostEventPageState extends State<EditPostEventPage> {
                   await _updateEvent();
                   Navigator.pop(context);
                 },
-                child: const Text('Submit'),
+                child: const Text('Update'),
               ),
             ],
           ),

--- a/flutter/wtc/lib/pages/edit_event.dart
+++ b/flutter/wtc/lib/pages/edit_event.dart
@@ -206,7 +206,7 @@ class _EditPostEventPageState extends State<EditPostEventPage> {
 
     // Show a snackbar as feedback
     ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text('Post submitted successfully')),
+      const SnackBar(content: Text('Event Updated Successfully')),
     );
   }
 

--- a/flutter/wtc/lib/pages/edit_job.dart
+++ b/flutter/wtc/lib/pages/edit_job.dart
@@ -195,7 +195,7 @@ class _EditPostJobPageState extends State<EditPostJobPage> {
                   await _updateJob();
                   Navigator.pop(context);
                 },
-                child: const Text('Submit'),
+                child: const Text('Update'),
               ),
             ],
           ),

--- a/flutter/wtc/lib/pages/edit_job.dart
+++ b/flutter/wtc/lib/pages/edit_job.dart
@@ -1,0 +1,206 @@
+import 'package:flutter/material.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter_guid/flutter_guid.dart';
+import 'package:intl/intl.dart';
+import 'package:wtc/widgets/job_post/job_post.dart';
+
+class EditPostJobPage extends StatefulWidget {
+  const EditPostJobPage({super.key, required this.post});
+
+  final JobPost post;
+
+  @override
+  State<EditPostJobPage> createState() => _EditPostJobPageState();
+}
+
+class _EditPostJobPageState extends State<EditPostJobPage> {
+  // Text editing controllers to capture input from text fields
+  final TextEditingController _titleController = TextEditingController();
+  final TextEditingController _headerController = TextEditingController();
+  final TextEditingController _descriptionController = TextEditingController();
+  final TextEditingController _tagsController = TextEditingController();
+  final TextEditingController _wageController = TextEditingController();
+  bool _isVolunteer = false;
+  String _wageType = 'hourly'; // Default to hourly
+
+  @override
+  void dispose() {
+    // Dispose controllers when the widget is removed from the widget tree
+    _titleController.dispose();
+    _descriptionController.dispose();
+    _tagsController.dispose();
+    _wageController.dispose();
+    super.dispose();
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _titleController.text = widget.post.title;
+    _headerController.text = widget.post.header;
+    _descriptionController.text = widget.post.body;
+    _wageController.text = widget.post.wage.toString();
+    _isVolunteer = widget.post.volunteer;
+    _wageType = widget.post.wageType;
+  }
+
+  Future<void> _updateJob() async {
+    // Validation checks for required fields
+    if (_titleController.text.isEmpty || _descriptionController.text.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Title and description are required')),
+      );
+      return; // Exit the function if validation fails
+    }
+
+    // Check if the text fields have at least 4 characters
+    if (_titleController.text.length < 4 ||
+        _descriptionController.text.length < 4 ||
+        _headerController.text.length < 4) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+            content: Text('Each field must have at least 4 characters')),
+      );
+      return; // Exit the function if validation fails
+    }
+
+    if (_titleController.text.length > 60 ||
+        _headerController.text.length > 60) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+            content: Text(
+                'Title or quick description can have no more than 60 characters.')),
+      );
+      return; // Exit the function if validation fails
+    }
+
+    if (!_isVolunteer) {
+      // Check if wage is empty
+      if (_wageController.text.isEmpty) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Wage is required')),
+        );
+        return; // Exit the function if validation fails
+      }
+
+      // Check if wage is a valid double
+      double? wage = double.tryParse(_wageController.text);
+      if (wage == null) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Please enter a valid wage amount')),
+        );
+        return; // Exit the function if validation fails
+      }
+    }
+
+    await FirebaseFirestore.instance
+        .collection('_posts')
+        .doc(widget.post.postId.toString())
+        .update({
+      'body': _descriptionController.text,
+      'header': _headerController.text,
+      'title': _titleController.text,
+      'type': _isVolunteer ? 'Volunteer' : 'Job',
+      'wage': _isVolunteer ? 0 : double.parse(_wageController.text),
+      'wageType': _isVolunteer ? 'N/A' : _wageType,
+      'isVolunteer': _isVolunteer,
+    });
+
+    // Clear the fields
+    _titleController.clear();
+    _headerController.clear();
+    _descriptionController.clear();
+    _tagsController.clear();
+    _wageController.clear();
+
+    // Show a success feedback
+    if (_isVolunteer) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Volunteer Updated Successfully')),
+      );
+    } else {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Job Updated Successfully')),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Create Job Post'),
+      ),
+      body: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Column(
+            children: [
+              TextField(
+                controller: _titleController,
+                decoration: const InputDecoration(
+                  labelText: 'Title',
+                ),
+              ),
+              const SizedBox(height: 16.0),
+              TextField(
+                controller: _headerController,
+                decoration: const InputDecoration(
+                  labelText: 'Quick description',
+                ),
+                minLines: 1,
+                maxLines: 2,
+              ),
+              const SizedBox(height: 16.0),
+              TextField(
+                controller: _descriptionController,
+                decoration: const InputDecoration(
+                  labelText: 'Description',
+                ),
+                minLines: 1,
+                maxLines: 5,
+              ),
+              const SizedBox(height: 16.0),
+              if (!_isVolunteer) ...[
+                TextField(
+                  controller: _wageController,
+                  decoration: const InputDecoration(
+                    labelText: 'Wage',
+                    hintText: 'Enter wage amount',
+                  ),
+                  keyboardType: TextInputType.numberWithOptions(decimal: true),
+                ),
+                const SizedBox(height: 16.0),
+                DropdownButton<String>(
+                  value: _wageType,
+                  items: <String>['hourly', 'salary'].map((String value) {
+                    return DropdownMenuItem<String>(
+                      value: value,
+                      child: Text(value),
+                    );
+                  }).toList(),
+                  onChanged: (String? newValue) {
+                    setState(() {
+                      if (newValue != null) {
+                        _wageType = newValue;
+                      }
+                    });
+                  },
+                ),
+              ],
+              const SizedBox(height: 32.0),
+              ElevatedButton(
+                onPressed: () async {
+                  await _updateJob();
+                  Navigator.pop(context);
+                },
+                child: const Text('Submit'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/flutter/wtc/lib/pages/edit_post.dart
+++ b/flutter/wtc/lib/pages/edit_post.dart
@@ -155,7 +155,7 @@ class _EditPostPageState extends State<EditPostPage> {
 
     // Show a snackbar as feedback
     ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text('Post Edited successfully')),
+      const SnackBar(content: Text('Post Updated Successfully')),
     );
   }
 

--- a/flutter/wtc/lib/pages/edit_post.dart
+++ b/flutter/wtc/lib/pages/edit_post.dart
@@ -1,0 +1,226 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter_guid/flutter_guid.dart';
+import 'package:intl/intl.dart';
+import 'package:wtc/widgets/post_widgets/post.dart';
+
+class EditPostPage extends StatefulWidget {
+  const EditPostPage({super.key, required this.post});
+
+  final Post post;
+
+  @override
+  State<EditPostPage> createState() => _EditPostPageState();
+}
+
+class _EditPostPageState extends State<EditPostPage> {
+  // Text editing controllers to capture input from text fields
+  final TextEditingController _titleController = TextEditingController();
+  final TextEditingController _descriptionController = TextEditingController();
+  final TextEditingController _headerController = TextEditingController();
+  final TextEditingController _tagsController = TextEditingController();
+  Map<String, bool> tags = {
+    'Eastern': false,
+    'Traffic': false,
+    'Accident': false,
+    'Weather': false,
+    'Construction': false,
+    'Event': false,
+  };
+  bool _isAlert = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _titleController.text = widget.post.title;
+    _headerController.text = widget.post.header;
+    _descriptionController.text = widget.post.body;
+    for (String tag in widget.post.tags) {
+      if (tags[tag] != null) {
+        tags[tag] = true;
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    // Dispose controllers when the widget is removed from the widget tree
+    _titleController.dispose();
+    _descriptionController.dispose();
+    _headerController.dispose();
+    super.dispose();
+  }
+
+  void showTags() {
+    showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: const Text('Select Tags'),
+          content: StatefulBuilder(
+            builder: (BuildContext context, StateSetter setState) {
+              return Column(
+                mainAxisSize: MainAxisSize.min,
+                children: tags.keys.map((String tag) {
+                  return CheckboxListTile(
+                    title: Text(tag),
+                    value: tags[tag],
+                    onChanged: (bool? value) {
+                      setState(() {
+                        // Update the selection state of the tag
+                        tags[tag] = value!;
+                      });
+                    },
+                  );
+                }).toList(),
+              );
+            },
+          ),
+          actions: <Widget>[
+            TextButton(
+              onPressed: () {
+                Navigator.of(context).pop();
+              },
+              child: const Text('Done'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  Future<void> _updatePost() async {
+    // Check if the title or description fields are empty
+    if (_titleController.text.isEmpty ||
+        _descriptionController.text.isEmpty ||
+        _headerController.text.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('All fields are required')),
+      );
+      return; // Exit the function if validation fails
+    }
+
+    // Check if the text fields have at least 4 characters
+    if (_titleController.text.length < 4 ||
+        _descriptionController.text.length < 4 ||
+        _headerController.text.length < 4) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+            content: Text('Each field must have at least 4 characters')),
+      );
+      return; // Exit the function if validation fails
+    }
+
+    if (_titleController.text.length > 60 ||
+        _headerController.text.length > 60) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+            content: Text(
+                'Title or quick description can have no more than 60 characters.')),
+      );
+      return; // Exit the function if validation fails
+    }
+
+    bool anyTagSelected = tags.values.any((val) => val);
+    if (!anyTagSelected) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('At least one tag must be selected')),
+      );
+      return; // Exit the function if no tags are selected
+    }
+
+    var convertedTags = [];
+    for (String key in tags.keys) {
+      if (tags[key] == true) {
+        convertedTags.add(key);
+      }
+    }
+
+    await FirebaseFirestore.instance
+        .collection('_posts')
+        .doc(widget.post.postId.toString())
+        .update({
+      'body': _descriptionController.text,
+      'header': _headerController.text,
+      'tags': convertedTags,
+      'title': _titleController.text,
+    });
+
+    // Clear the fields
+    _titleController.clear();
+    _descriptionController.clear();
+    _headerController.clear();
+    _tagsController.clear();
+
+    // Show a snackbar as feedback
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Post Edited successfully')),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Edit Post'),
+      ),
+      body: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Column(
+            children: [
+              TextField(
+                controller: _titleController,
+                decoration: const InputDecoration(
+                  labelText: 'Title',
+                ),
+              ),
+              const SizedBox(height: 16.0),
+              TextField(
+                controller: _headerController,
+                decoration: const InputDecoration(
+                  labelText: 'Quick description',
+                ),
+                minLines: 1,
+                maxLines: 2,
+              ),
+              const SizedBox(height: 16.0),
+              TextField(
+                controller: _descriptionController,
+                decoration: const InputDecoration(
+                  labelText: 'Description',
+                ),
+                minLines: 1,
+                maxLines: 5,
+              ),
+              CheckboxListTile(
+                title: const Text('Alert'),
+                value: _isAlert,
+                onChanged: (bool? value) {
+                  setState(() {
+                    _isAlert = value!;
+                  });
+                },
+              ),
+              const SizedBox(height: 16.0),
+              ElevatedButton(
+                onPressed: showTags,
+                child: const Text('Select Tags'),
+              ),
+              //Submit button
+              const SizedBox(height: 16.0),
+              ElevatedButton(
+                onPressed: () async {
+                  await _updatePost();
+                  Navigator.pop(context);
+                },
+                child: const Text('Update'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/flutter/wtc/lib/pages/edit_post.dart
+++ b/flutter/wtc/lib/pages/edit_post.dart
@@ -194,15 +194,6 @@ class _EditPostPageState extends State<EditPostPage> {
                 minLines: 1,
                 maxLines: 5,
               ),
-              CheckboxListTile(
-                title: const Text('Alert'),
-                value: _isAlert,
-                onChanged: (bool? value) {
-                  setState(() {
-                    _isAlert = value!;
-                  });
-                },
-              ),
               const SizedBox(height: 16.0),
               ElevatedButton(
                 onPressed: showTags,

--- a/flutter/wtc/lib/widgets/event_widgets/event_calendar.dart
+++ b/flutter/wtc/lib/widgets/event_widgets/event_calendar.dart
@@ -178,6 +178,8 @@ class _EventCalendar extends State<EventCalendar> {
           } else {
             hour = int.parse(time[0].split(":")[0]) + 12;
           }
+        } else {
+          hour = int.parse(time[0].split(":")[0]);
         }
         int minute = int.parse(time[0].split(":")[1]);
         Event event = Event(

--- a/flutter/wtc/lib/widgets/post_widgets/post_delete_edit_box.dart
+++ b/flutter/wtc/lib/widgets/post_widgets/post_delete_edit_box.dart
@@ -1,6 +1,7 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:wtc/pages/edit_event.dart';
+import 'package:wtc/pages/edit_job.dart';
 import 'package:wtc/pages/edit_post.dart';
 import 'package:wtc/widgets/event_widgets/event.dart';
 import 'package:wtc/widgets/job_post/job_post.dart';
@@ -31,6 +32,12 @@ class PostDeleteEditBox extends StatelessWidget {
                         EditPostEventPage(post: post as Event)),
               );
             } else if (post is JobPost) {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                    builder: (context) =>
+                        EditPostJobPage(post: post as JobPost)),
+              );
             } else {
               Navigator.push(
                 context,

--- a/flutter/wtc/lib/widgets/post_widgets/post_delete_edit_box.dart
+++ b/flutter/wtc/lib/widgets/post_widgets/post_delete_edit_box.dart
@@ -1,5 +1,9 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
+import 'package:wtc/pages/edit_event.dart';
+import 'package:wtc/pages/edit_post.dart';
+import 'package:wtc/widgets/event_widgets/event.dart';
+import 'package:wtc/widgets/job_post/job_post.dart';
 import 'package:wtc/widgets/post_widgets/post.dart';
 
 class PostDeleteEditBox extends StatelessWidget {
@@ -18,7 +22,23 @@ class PostDeleteEditBox extends StatelessWidget {
               style: TextStyle(fontSize: 24, color: Colors.red))),
       const SizedBox(width: 60),
       TextButton(
-          onPressed: () {},
+          onPressed: () {
+            if (post is Event) {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                    builder: (context) =>
+                        EditPostEventPage(post: post as Event)),
+              );
+            } else if (post is JobPost) {
+            } else {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                    builder: (context) => EditPostPage(post: post)),
+              );
+            }
+          },
           child: const Text("Edit",
               style: TextStyle(fontSize: 24, color: Color(0xFF469AB8)))),
     ]);

--- a/flutter/wtc/lib/widgets/post_widgets/post_list.dart
+++ b/flutter/wtc/lib/widgets/post_widgets/post_list.dart
@@ -53,6 +53,8 @@ class PostList extends StatelessWidget {
                   } else {
                     hour = int.parse(time[0].split(":")[0]) + 12;
                   }
+                } else {
+                  hour = int.parse(time[0].split(":")[0]);
                 }
                 int minute = int.parse(time[0].split(":")[1]);
 

--- a/flutter/wtc/lib/widgets/post_widgets/post_review.dart
+++ b/flutter/wtc/lib/widgets/post_widgets/post_review.dart
@@ -23,7 +23,6 @@ class PostReview extends Post {
           header: header,
           tags: tags,
           body: body,
-          user: user,
           userEmail: userEmail,
           interestCount: interestCount,
           created: created,


### PR DESCRIPTION
1. Added three new pages: edit_post.dart, edit_event.dart, and edit_job.dart.
2. The PostDeleteEditBox now checks the type of the post being passed and routes the user to the appropriate edit post page.
3. The edit post page allows users to edit a basic post.
4. The edit event page allows users to edit an event: date, time, etc. and will display the updated event in the calendar.
5. The edit job page displays the proper text fields depending on whether the post is a job or a volunteer position.
6. Once a user presses the "Update" button it will pop the edit page off the stack and display the previous page.