### PR TITLE
edit profile hotfix/ styling

### DIFF
--- a/flutter/wtc/lib/pages/edit_profile.dart
+++ b/flutter/wtc/lib/pages/edit_profile.dart
@@ -96,6 +96,10 @@ class _EditProfile extends State<EditProfile>{
           ),
         ),
         backgroundColor: const Color(0xFF469AB8),
+        centerTitle: true,
+        iconTheme: const IconThemeData(
+          color: Colors.white
+        ) ,
       ),
       body: Center(
         child: SingleChildScrollView(
@@ -220,6 +224,14 @@ class _EditProfile extends State<EditProfile>{
 
                       if(confirm){
 
+                        showDialog(
+                          context: context,
+                          builder: (context) => const Center(
+                            child: CircularProgressIndicator(),
+                          )
+                        );
+
+                        if(selectedImage != null){
                           Reference ref = FirebaseStorage.instance
                             .ref('profilePictures')
                             .child('${widget.uid}.jpg');
@@ -229,6 +241,7 @@ class _EditProfile extends State<EditProfile>{
                           String newPfp = await ref.getDownloadURL();
 
                           setPfp(newPfp);
+                        }
 
                         if(usernameController.text.isEmpty){
                           usernameController.text = widget.username;
@@ -241,6 +254,7 @@ class _EditProfile extends State<EditProfile>{
                         if(passwordController.text.isNotEmpty && passwordController.text == confirmPasswordController.text){
                           await currentUser?.updatePassword(passwordController.text);
                         }
+                        Navigator.of(context).pop();
                         Navigator.of(context).pop();
                       }
                     }

--- a/flutter/wtc/lib/pages/edit_tags.dart
+++ b/flutter/wtc/lib/pages/edit_tags.dart
@@ -118,6 +118,9 @@ class _EditTagsState extends State<EditTags> {
         ),
         centerTitle: true,
         backgroundColor: const Color(0xFF469AB8),
+        iconTheme: const IconThemeData(
+          color: Colors.white
+        ),
       ),
 
       body: Center(
@@ -131,7 +134,7 @@ class _EditTagsState extends State<EditTags> {
                 child: Padding(
                   padding: EdgeInsets.all(8.0),
                   child: Text(
-                    "Select Tags:",
+                    "Select Tags",
                     style: TextStyle(
                       fontSize: 21,
                       fontWeight: FontWeight.bold


### PR DESCRIPTION
1. Edit profile works again
2. Edit profile has a loading circle when making changes/ uploading pfp
3. 'Edit Profile' title centered 
4. Back button icons for the edit profile and edit tags are now white