### PR TITLE
Created search user page.

### DIFF
--- a/flutter/wtc/lib/app.dart
+++ b/flutter/wtc/lib/app.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:wtc/pages/search_user.dart';
 import 'widgets/navbutton.dart';
 import 'User/user_service.dart';
 import 'pages/home.dart';
@@ -42,6 +43,7 @@ class _NavBars extends State<App> {
   bool showVolunteerPage = false;
   bool showApprovePostsPage = false;
   bool showAboutUsPage = false;
+  bool showSearchUsers = false;
   String title = "Welcome To Cheney";
   String prevTitle = "";
   String userTier = "";
@@ -143,6 +145,7 @@ class _NavBars extends State<App> {
                 showNotification = false;
                 showApprovePostsPage = false;
                 showAboutUsPage = false;
+                showSearchUsers = false;
               });
             },
           ),
@@ -160,6 +163,7 @@ class _NavBars extends State<App> {
                 showNotification = false;
                 showApprovePostsPage = false;
                 showAboutUsPage = false;
+                showSearchUsers = false;
               });
             },
           ),
@@ -178,6 +182,7 @@ class _NavBars extends State<App> {
                 showNotification = false;
                 showApprovePostsPage = false;
                 showAboutUsPage = false;
+                showSearchUsers = false;
               });
             },
           ),
@@ -195,6 +200,7 @@ class _NavBars extends State<App> {
                 showVolunteerPage = !showVolunteerPage;
                 showApprovePostsPage = false;
                 showAboutUsPage = false;
+                showSearchUsers = false;
               });
             },
           ),
@@ -213,6 +219,7 @@ class _NavBars extends State<App> {
                 showNotification = false;
                 showApprovePostsPage = false;
                 showAboutUsPage = false;
+                showSearchUsers = false;
               });
             },
           ),
@@ -229,6 +236,7 @@ class _NavBars extends State<App> {
                       showNotification = false;
                       showApprovePostsPage = false;
                       showAboutUsPage = false;
+                      showSearchUsers = false;
                     });
                   },
                 )
@@ -259,6 +267,25 @@ class _NavBars extends State<App> {
                   showNotification = false;
                   showJobsPage = false;
                   showAboutUsPage = false;
+                  showSearchUsers = false;
+                });
+              },
+            ),
+          if (userTier == "Admin")
+            ListTile(
+              leading: const Icon(Icons.search),
+              title: const Text('Search Users'),
+              onTap: () {
+                Navigator.pop(context);
+                setState(() {
+                  title = "Search Users";
+                  prevTitle = "Search Users";
+                  showApprovePostsPage = false;
+                  showVolunteerPage = false;
+                  showNotification = false;
+                  showJobsPage = false;
+                  showAboutUsPage = false;
+                  showSearchUsers = !showSearchUsers;
                 });
               },
             ),
@@ -276,6 +303,7 @@ class _NavBars extends State<App> {
                 showNotification = false;
                 showVolunteerPage = false;
                 showApprovePostsPage = false;
+                showSearchUsers = false;
               });
             },
           ),
@@ -319,7 +347,8 @@ class _NavBars extends State<App> {
           if (showJobsPage) const JobsPage(),
           if (showVolunteerPage) const VolunteerPage(),
           if (showApprovePostsPage) const AdminReviewPage(),
-          if (showAboutUsPage) const AboutUsPage()
+          if (showAboutUsPage) const AboutUsPage(),
+          if (showSearchUsers) const SearchUserPage()
         ],
       ),
       bottomNavigationBar: NavigationBar(
@@ -336,6 +365,7 @@ class _NavBars extends State<App> {
             showNotification = false;
             showApprovePostsPage = false;
             showAboutUsPage = false;
+            showSearchUsers = false;
           });
         },
         indicatorColor: Colors.white,
@@ -378,6 +408,8 @@ class _NavBars extends State<App> {
       case 5:
         return "Approve Posts";
       case 6:
+        return "Search Users";
+      case 7:
         return "About us";
       default:
         return "Welcome to Cheney";

--- a/flutter/wtc/lib/pages/search_user.dart
+++ b/flutter/wtc/lib/pages/search_user.dart
@@ -1,0 +1,98 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+import 'package:wtc/widgets/user_widgets/search_user_info.dart';
+
+class SearchUserPage extends StatefulWidget {
+  const SearchUserPage({super.key});
+
+  @override
+  State<SearchUserPage> createState() => _SearchUserPageState();
+}
+
+class _SearchUserPageState extends State<SearchUserPage> {
+  final TextEditingController _searchController = TextEditingController();
+  final FirebaseFirestore _firestore = FirebaseFirestore.instance;
+  List<QueryDocumentSnapshot> allUsers = [];
+  List<QueryDocumentSnapshot> filteredUsers = [];
+
+  @override
+  void initState() {
+    super.initState();
+    getAllUsers();
+  }
+
+  Future<void> getAllUsers() async {
+    var querySnapshot = await _firestore.collection('users').get();
+    setState(() {
+      allUsers = querySnapshot.docs;
+      filteredUsers = querySnapshot.docs;
+    });
+  }
+
+  void filterUsers(String query) {
+    if (query.isEmpty) {
+      setState(() {
+        filteredUsers = allUsers;
+      });
+    } else {
+      List<QueryDocumentSnapshot> tmpList = [];
+      for (var user in allUsers) {
+        var username = user['username'].toString().toLowerCase();
+        var email = user['email'].toString().toLowerCase();
+        if (username.contains(query.toLowerCase()) ||
+            email.contains(query.toLowerCase())) {
+          tmpList.add(user);
+        }
+      }
+      setState(() {
+        filteredUsers = tmpList;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+        body: Column(
+      children: <Widget>[
+        Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: TextField(
+            controller: _searchController,
+            decoration: const InputDecoration(
+              labelText: 'Search User',
+              hintText: 'Search user by email or username',
+              prefixIcon: Icon(Icons.search),
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.all(Radius.circular(25.0)),
+              ),
+            ),
+            onChanged: filterUsers,
+          ),
+        ),
+        Expanded(
+          child: ListView.separated(
+            padding: const EdgeInsets.all(8),
+            itemCount: filteredUsers.length,
+            itemBuilder: (BuildContext context, int index) {
+              return SearchUserInfo(
+                  email: filteredUsers[index]['email'] as String,
+                  username: filteredUsers[index]['username'] as String,
+                  name: filteredUsers[index]['name'] as String,
+                  tier: filteredUsers[index]['tier'] as String,
+                  pfp: filteredUsers[index]['pfp'] as String);
+            },
+            separatorBuilder: (BuildContext context, int index) =>
+                const Divider(),
+          ),
+        )
+      ],
+    ));
+  }
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+}

--- a/flutter/wtc/lib/widgets/user_widgets/search_user_info.dart
+++ b/flutter/wtc/lib/widgets/user_widgets/search_user_info.dart
@@ -1,0 +1,51 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+
+class SearchUserInfo extends StatelessWidget {
+  const SearchUserInfo(
+      {super.key,
+      required this.email,
+      required this.username,
+      required this.name,
+      required this.tier,
+      required this.pfp});
+
+  final String email;
+  final String username;
+  final String name;
+  final String tier;
+  final String pfp;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        ClipRRect(
+          borderRadius: BorderRadius.circular(50),
+          child: CachedNetworkImage(
+            imageUrl: pfp,
+            placeholder: (context, url) => const CircularProgressIndicator(),
+            errorWidget: (context, url, error) => const Image(
+                image: AssetImage('images/profile.jpg'),
+                width: 120,
+                height: 120),
+            memCacheHeight: 120,
+            memCacheWidth: 120,
+            fit: BoxFit.cover,
+          ),
+        ),
+        Column(
+          children: [
+            Text("Email: $email"),
+            const SizedBox(height: 10),
+            Text("Username: $username"),
+            const SizedBox(height: 10),
+            Text("Name: $name"),
+            const SizedBox(height: 10),
+            Text("Tier: $tier"),
+          ],
+        )
+      ],
+    );
+  }
+}


### PR DESCRIPTION
- Created SearchUserPage and SearchUserInfo widgets

- "Search User" added to hamburger menu.

- On the search user page all users are displayed by default.

- When an admin types text into the search bar it filters the users by email and username and only displays a user if their email or username contains the search string.

- The SearchUserInfo widget currently displays the users pfp, email, username, name, and tier. This may be modified depending on Maria's needs.

- The entire list of users is currently pulled from the DB when the Search Users page is opened. This is necessary since there is no way to perform substring checks inside of Firestore without the help of another third party service. This means that if a user changes their username while an admin is currently viewing the Search Users page that change will not be reflected until the admin re-opens the Search Users page.