### PR TITLE
Account upgrade

### DIFF
--- a/flutter/wtc/lib/accountPages/account_upgrade.dart
+++ b/flutter/wtc/lib/accountPages/account_upgrade.dart
@@ -9,11 +9,13 @@ class AccountUpgradePage extends StatefulWidget {
     required this.tier, 
     required this.name, 
     required this.email,
+    required this.uid
   });
 
   final String tier;
   final String name;
   final String email;
+  final String uid;
 
   @override
   State<AccountUpgradePage> createState() => _AccountUpgradePageState();
@@ -73,7 +75,7 @@ class _AccountUpgradePageState extends State<AccountUpgradePage> {
     // Upload to database
     await FirebaseFirestore.instance
       .collection("_review_account")
-      .doc()
+      .doc(widget.uid)
       .set({
         "name": name,
         "about": about,

--- a/flutter/wtc/lib/accountPages/account_upgrade.dart
+++ b/flutter/wtc/lib/accountPages/account_upgrade.dart
@@ -1,0 +1,545 @@
+import "package:cloud_firestore/cloud_firestore.dart";
+import "package:flutter/material.dart";
+import "package:intl_phone_number_input/intl_phone_number_input.dart";
+
+
+class AccountUpgradePage extends StatefulWidget {
+  const AccountUpgradePage({
+    super.key, 
+    required this.tier, 
+    required this.name, 
+    required this.email,
+  });
+
+  final String tier;
+  final String name;
+  final String email;
+
+  @override
+  State<AccountUpgradePage> createState() => _AccountUpgradePageState();
+}
+
+class _AccountUpgradePageState extends State<AccountUpgradePage> {
+
+  final TextEditingController _nameController = TextEditingController();
+  final TextEditingController _bioController = TextEditingController();
+  final TextEditingController _addressController = TextEditingController();
+  final TextEditingController _phoneController = TextEditingController();
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _bioController.dispose();
+    _addressController.dispose();
+    super.dispose();
+  }
+
+  String mondayOpen = "";
+  String mondayClose = "";
+  String tuesdayOpen = "";
+  String tuesdayClose = "";
+  String wednesdayOpen = "";
+  String wednesdayClose = "";
+  String thursdayOpen = "";
+  String thursdayClose = "";
+  String fridayOpen = "";
+  String fridayClose = "";
+  String saturdayOpen = "";
+  String saturdayClose = "";
+  String sundayOpen = "";
+  String sundayClose = "";
+
+  bool isBusiness = false;
+
+  Future<void> submitApplication(String email, bool isBusiness) async {
+
+    // Get the values from the text fields
+    String name = _nameController.text.trim();
+    String about = _bioController.text.trim();
+    String address = _addressController.text.trim();
+    String phone = _phoneController.text.trim();
+
+    // Create a map of the business hours
+    Map<String, String> businessHours = {
+      "Monday": "$mondayOpen - $mondayClose",
+      "Tuesday": "$tuesdayOpen - $tuesdayClose",
+      "Wednesday": "$wednesdayOpen - $wednesdayClose",
+      "Thursday": "$thursdayOpen - $thursdayClose",
+      "Friday": "$fridayOpen - $fridayClose",
+      "Saturday": "$saturdayOpen - $saturdayClose",
+      "Sunday": "$sundayOpen - $sundayClose",
+    };
+
+    // Upload to database
+    await FirebaseFirestore.instance
+      .collection("_review_account")
+      .doc()
+      .set({
+        "name": name,
+        "about": about,
+        "phone": phone,
+        "isBusiness": isBusiness,
+        "address": address,
+        "businessHours": businessHours,
+        "email": email,
+      }
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+
+    bool isPoster = widget.tier == "Poster";
+    if(isPoster){ 
+      isBusiness = true;
+    }
+    
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text(
+          "Upgrade Account Application",
+          style: TextStyle(
+            color: Colors.white
+          ),
+        ),
+        backgroundColor: const Color(0xFF469AB8),
+        centerTitle: true,
+        iconTheme: const IconThemeData(color: Colors.white),
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          children: [
+
+            // isBusiness button
+            if(!isPoster)
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                const Text(
+                  "Are you a business?",
+                  style: TextStyle(
+                    fontSize: 17,
+                  ),
+                  textAlign: TextAlign.start,
+                ),
+                Switch(
+                  activeColor: Colors.grey[600],
+                  value: isBusiness,
+                  onChanged: (value) {
+                    setState(() {
+                      isBusiness = value;
+                    });
+                  },
+                ),
+              ],
+            ),
+
+            if(!isPoster)
+            const SizedBox(height: 10),
+
+            if (isBusiness) 
+              Column(
+                children: [
+                  // Business Name
+                  TextField(
+                    controller: _nameController,
+                    decoration: const InputDecoration(
+                      labelText: "Business Name",
+                    ),
+                  ),
+
+                  const SizedBox(height: 20),
+
+                  // Business Description
+                  TextField(
+                    controller: _bioController,
+                    decoration: const InputDecoration(
+                      labelText: "Business Description",
+                      hintText: "What does your business do?"
+                    ),
+                  ),
+
+                  const SizedBox(height: 20),
+
+                  // Business Address
+                  TextField(
+                    controller: _addressController,
+                    decoration: const InputDecoration(
+                      labelText: "Business Address",
+                    ),
+                  ),
+
+                  const SizedBox(height: 20),
+
+                  // Business Number
+                  InternationalPhoneNumberInput(
+                    onInputChanged: (PhoneNumber number) {
+                      _phoneController.text = number.phoneNumber!;
+                    },
+                    inputDecoration: const InputDecoration(
+                      
+                    ),
+                    maxLength: 12,
+                    selectorConfig: const SelectorConfig(
+                      selectorType: PhoneInputSelectorType.BOTTOM_SHEET,
+                    ),
+                    countries: const ["US"],
+                  ),
+
+                  const SizedBox(height: 20),
+
+                  // Business Hours
+                  const Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      Text(
+                        "\tBusiness Hours",
+                        style: TextStyle(
+                          fontSize: 17,
+                        ),
+                        textAlign: TextAlign.start,
+                      ),
+                    ],
+                  ),
+
+                  
+                  DataTable(
+                    columns: const [
+                      DataColumn(label: Text("Day")),
+                      DataColumn(label: Text("Open")),
+                      DataColumn(label: Text("Close")),
+                    ],
+                    rows: [
+                      DataRow(cells: [
+                        const DataCell(Text("Monday")),
+                        DataCell(
+                          onTap:(){
+                            showTimePicker(
+                              context: context, 
+                              initialTime: TimeOfDay.now(),
+                              initialEntryMode: TimePickerEntryMode.input,
+                            ).then((value){
+                              if(value != null){
+                                setState(() {
+                                  mondayOpen = value.format(context);
+                                });
+                              }
+                            });
+                          },
+                          Text(mondayOpen),
+                        ),
+                        DataCell(
+                          onTap:(){
+                            showTimePicker(
+                              context: context, 
+                              initialTime: TimeOfDay.now(),
+                              initialEntryMode: TimePickerEntryMode.input,
+                            ).then((value){
+                              if(value != null){
+                                setState(() {
+                                  mondayClose = value.format(context);
+                                });
+                              }
+                            });
+                          },                      
+                          Text(mondayClose),
+                        ),
+                      ]),
+                      DataRow(cells: [
+                        const DataCell(Text("Tuesday")),
+                        DataCell(
+                          onTap:(){
+                            showTimePicker(
+                              context: context, 
+                              initialTime: TimeOfDay.now(),
+                              initialEntryMode: TimePickerEntryMode.input,
+                            ).then((value){
+                              if(value != null){
+                                setState(() {
+                                  tuesdayOpen = value.format(context);
+                                });
+                              }
+                            });
+                          },
+                          Text(tuesdayOpen)
+                          ),
+                        DataCell(
+                          onTap:(){
+                            showTimePicker(
+                              context: context, 
+                              initialTime: TimeOfDay.now(),
+                              initialEntryMode: TimePickerEntryMode.input,
+                            ).then((value){
+                              if(value != null){
+                                setState(() {
+                                  tuesdayClose = value.format(context);
+                                });
+                              }
+                            });
+                          },
+                          Text(tuesdayClose)
+                          ),
+                      ]),
+                      DataRow(cells: [
+                        const DataCell(Text("Wednesday")),
+                        DataCell(
+                          onTap:(){
+                            showTimePicker(
+                              context: context, 
+                              initialTime: TimeOfDay.now(),
+                              initialEntryMode: TimePickerEntryMode.input,
+                            ).then((value){
+                              if(value != null){
+                                setState(() {
+                                  wednesdayOpen = value.format(context);
+                                });
+                              }
+                            });
+                          },
+                          Text(wednesdayOpen)
+                          ),
+                        DataCell(
+                          onTap:(){
+                            showTimePicker(
+                              context: context, 
+                              initialTime: TimeOfDay.now(),
+                              initialEntryMode: TimePickerEntryMode.input,
+                            ).then((value){
+                              if(value != null){
+                                setState(() {
+                                  wednesdayClose = value.format(context);
+                                });
+                              }
+                            });
+                          },
+                          Text(wednesdayClose)
+                          ),
+                      ]),
+                      DataRow(cells: [
+                        const DataCell(Text("Thursday")),
+                        DataCell(
+                          onTap:(){
+                            showTimePicker(
+                              context: context, 
+                              initialTime: TimeOfDay.now(),
+                              initialEntryMode: TimePickerEntryMode.input,
+                            ).then((value){
+                              if(value != null){
+                                setState(() {
+                                  thursdayOpen = value.format(context);
+                                });
+                              }
+                            });
+                          },
+                          Text(thursdayOpen)
+                          ),
+                        DataCell(
+                          onTap:(){
+                            showTimePicker(
+                              context: context, 
+                              initialTime: TimeOfDay.now(),
+                              initialEntryMode: TimePickerEntryMode.input,
+                            ).then((value){
+                              if(value != null){
+                                setState(() {
+                                  thursdayClose = value.format(context);
+                                });
+                              }
+                            });
+                          },
+                          Text(thursdayClose)
+                          ),
+                      ]),
+                      DataRow(cells: [
+                        const DataCell(Text("Friday")),
+                        DataCell(
+                          onTap:(){
+                            showTimePicker(
+                              context: context, 
+                              initialTime: TimeOfDay.now(),
+                              initialEntryMode: TimePickerEntryMode.input,
+                            ).then((value){
+                              if(value != null){
+                                setState(() {
+                                  fridayOpen = value.format(context);
+                                });
+                              }
+                            });
+                          },
+                          Text(fridayOpen)
+                          ),
+                        DataCell(
+                          onTap:(){
+                            showTimePicker(
+                              context: context, 
+                              initialTime: TimeOfDay.now(),
+                              initialEntryMode: TimePickerEntryMode.input,
+                            ).then((value){
+                              if(value != null){
+                                setState(() {
+                                  fridayClose = value.format(context);
+                                });
+                              }
+                            });
+                          },
+                          Text(fridayClose)
+                          ),
+                      ]),
+                      DataRow(cells: [
+                        const DataCell(Text("Saturday")),
+                        DataCell(
+                          onTap:(){
+                            showTimePicker(
+                              context: context, 
+                              initialTime: TimeOfDay.now(),
+                              initialEntryMode: TimePickerEntryMode.input,
+                            ).then((value){
+                              if(value != null){
+                                setState(() {
+                                  saturdayOpen = value.format(context);
+                                });
+                              }
+                            });
+                          },
+                          Text(saturdayOpen)
+                          ),
+                        DataCell(
+                          onTap:(){
+                            showTimePicker(
+                              context: context, 
+                              initialTime: TimeOfDay.now(),
+                              initialEntryMode: TimePickerEntryMode.input,
+                            ).then((value){
+                              if(value != null){
+                                setState(() {
+                                  saturdayClose = value.format(context);
+                                });
+                              }
+                            });
+                          },
+                          Text(saturdayClose)
+                          ),
+                      ]),
+                      DataRow(cells: [
+                        const DataCell(Text("Sunday")),
+                        DataCell(
+                          onTap:(){
+                            showTimePicker(
+                              context: context, 
+                              initialTime: TimeOfDay.now(),
+                              initialEntryMode: TimePickerEntryMode.input,
+                            ).then((value){
+                              if(value != null){
+                                setState(() {
+                                  sundayOpen = value.format(context);
+                                });
+                              }
+                            });
+                          },
+                          Text(sundayOpen)
+                          ),
+                        DataCell(
+                          onTap:(){
+                            showTimePicker(
+                              context: context, 
+                              initialTime: TimeOfDay.now(),
+                              initialEntryMode: TimePickerEntryMode.input,
+                            ).then((value){
+                              if(value != null){
+                                setState(() {
+                                  sundayClose = value.format(context);
+                                });
+                              }
+                            });
+                          },
+                          Text(sundayClose)
+                          ),
+                      ]),
+                    ],
+                  ),
+
+                  const SizedBox(height: 30),
+                ],
+              ),
+
+            if(!isBusiness)
+              Column(
+                children: [
+                  // Name
+                  TextField(
+                    controller: _nameController,
+                    decoration: const InputDecoration(
+                      labelText: "Name",
+                    ),
+                  ),
+
+                  const SizedBox(height: 20),
+
+                  // Bio
+                  TextField(
+                    controller: _bioController,
+                    decoration: const InputDecoration(
+                      labelText: "About yourself",
+                    ),
+                  ),
+
+                  const SizedBox(height: 20),
+
+                  // Phone Number
+                  InternationalPhoneNumberInput(
+                    onInputChanged: (PhoneNumber number) {
+                      _phoneController.text = number.phoneNumber!;
+                    },
+                    maxLength: 12,
+                    inputDecoration: const InputDecoration(
+                      labelText: "Phone Number",
+                      helperText: "If we need to contact you"
+                    ),
+                    selectorConfig: const SelectorConfig(
+                      selectorType: PhoneInputSelectorType.BOTTOM_SHEET,
+                    ),
+                    countries: const ["US"],
+                  ),
+                  
+
+                  const SizedBox(height: 30),
+                ],
+              ),
+
+            // Upgrade Button
+            ElevatedButton(
+              onPressed: () async{
+                if(_bioController.text.isEmpty || _nameController.text.isEmpty || _phoneController.text.isEmpty){
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(
+                      content: Text("Please fill out all fields"),
+                    ),
+                  );
+                }
+                else if(isBusiness && _addressController.text.isEmpty){
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(
+                      content: Text("Please fill out all fields"),
+                    ),
+                  );
+                }
+                else{
+                  await submitApplication(widget.email, isBusiness);           
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(
+                      content: Text("Application submitted successfully"),
+                    ),
+                  );
+                  Navigator.pop(context);
+                }
+              },
+              child: const Text("Submit"),
+            ),
+          ]
+        ),
+      ),
+      
+    );
+  }
+}

--- a/flutter/wtc/lib/accountPages/edit_business.dart
+++ b/flutter/wtc/lib/accountPages/edit_business.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+
+class EditBusinessInfo extends StatefulWidget {
+  const EditBusinessInfo({super.key});
+
+  @override
+  State<EditBusinessInfo> createState() => _EditBusinessInfoState();
+}
+
+class _EditBusinessInfoState extends State<EditBusinessInfo> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text(
+          "Edit Business Info",
+          style: TextStyle(
+            color: Colors.white
+          ),
+        ),
+        backgroundColor: const Color(0xFF469AB8),
+        centerTitle: true,
+        iconTheme: const IconThemeData(
+          color: Colors.white
+        ),
+      ),
+      body: const Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text("Edit Business Info"),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/flutter/wtc/lib/accountPages/edit_profile.dart
+++ b/flutter/wtc/lib/accountPages/edit_profile.dart
@@ -111,9 +111,15 @@ class _EditProfile extends State<EditProfile>{
 
                 //Pfp
                 selectedImage != null ?
-                  SizedBox(
+                  Container(
                   height: 120,
                   width: 120,
+                  decoration: BoxDecoration(
+                    border: Border.all(
+                      color: Colors.black,
+                    ),
+                    shape: BoxShape.circle
+                  ),
                   child: ClipRRect(
                     borderRadius: BorderRadius.circular(200),
                     child: Image.file(
@@ -123,12 +129,18 @@ class _EditProfile extends State<EditProfile>{
                   )
                 )
                 :
-                SizedBox(
+                Container(
                   height: 120,
                   width: 120,
+                  decoration: BoxDecoration(
+                    border: Border.all(
+                      color: Colors.black,
+                    ),
+                    shape: BoxShape.circle
+                  ),
                   child: ClipRRect(
                     borderRadius: BorderRadius.circular(200),
-                    child: widget.profilePic 
+                    child: widget.profilePic,                   
                   ),
                 ),
 

--- a/flutter/wtc/lib/accountPages/edit_settings.dart
+++ b/flutter/wtc/lib/accountPages/edit_settings.dart
@@ -219,6 +219,7 @@ class _EditSettingsState extends State<EditSettings> {
                           tier: widget.tier,
                           name: widget.name,
                           email: widget.email,
+                          uid: widget.uid,
                         )
                       )
                     );
@@ -255,6 +256,7 @@ class _EditSettingsState extends State<EditSettings> {
                           tier: widget.tier,
                           name: widget.name,
                           email: widget.email,
+                          uid: widget.uid,
                         )
                       )
                     );
@@ -280,6 +282,7 @@ class _EditSettingsState extends State<EditSettings> {
                 ),
               ),
 
+              if(widget.tier == "Poster" || widget.tier == "Viewer")
               const SizedBox(height: 20,),
 
               // delete account

--- a/flutter/wtc/lib/accountPages/edit_settings.dart
+++ b/flutter/wtc/lib/accountPages/edit_settings.dart
@@ -1,0 +1,316 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_storage/firebase_storage.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:wtc/accountPages/account_upgrade.dart';
+import 'package:wtc/accountPages/edit_business.dart';
+import 'package:wtc/accountPages/edit_profile.dart';
+import 'package:wtc/accountPages/edit_tags.dart';
+//import 'package:wtc/auth/login.dart';
+
+class EditSettings extends StatefulWidget {
+  const EditSettings(
+    {
+      super.key, 
+      required this.tier, 
+      required this.email, 
+      required this.tags, 
+      required this.isBusiness,
+      required this.username,
+      required this.name,
+      required this.profilePic,
+      required this.uid,
+    }
+  );
+
+  final String tier;
+  final String email;
+  final List<String> tags;
+  final bool isBusiness;
+  final String username;
+  final String name;
+  final CachedNetworkImage? profilePic;
+  final String uid;
+
+  @override
+  State<EditSettings> createState() => _EditSettingsState();
+}
+
+Future<void> deleteAccount(String email, List<String> tags, String uid) async{
+  //Delete user from users collection
+  await FirebaseFirestore.instance
+    .collection('users')
+    .doc(email.toLowerCase())
+    .delete();
+
+  // Delete user from tags collection
+
+  for(int i = 0; i < tags.length; i++){
+    await FirebaseFirestore.instance
+      .collection('tags')
+      .doc(tags[i])
+      .update({
+        'users': FieldValue.arrayRemove([email.toLowerCase()])
+      });
+  }
+
+  // Delete pfps from storage
+  await FirebaseStorage.instance
+    .ref()
+    .child('profile_pics/$uid')
+    .delete();
+
+  // Delete user from auth
+  try{
+    await FirebaseAuth.instance.currentUser!.delete();
+  }on FirebaseAuthException catch(e){
+    AlertDialog(
+      title: const Text("Error"),
+      content: Text(e.code),
+    );
+  }
+}
+
+Future<void> reauthenticateAndDelete() async{
+   //await FirebaseAuth.instance.currentUser!.reauthenticateWithCredential(credential)
+}
+
+class _EditSettingsState extends State<EditSettings> {
+  @override
+  Widget build(BuildContext context) {
+
+    List<String> origTags = [];
+    origTags.addAll(widget.tags);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text(
+          "Edit Settings",
+          style: TextStyle(
+            color: Colors.white,
+          ),
+        ),
+        centerTitle: true,
+        backgroundColor: const Color(0xFF469AB8),
+        iconTheme: const IconThemeData(
+          color: Colors.white,
+        ),
+      ),
+      body: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(25),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.start,
+            children: [
+
+              // edit profile
+              GestureDetector(
+                onTap: (){
+                  Navigator.push(
+                    context,
+                    CupertinoPageRoute(
+                      builder: (context) => EditProfile(
+                        uid: widget.uid,
+                        name: widget.name,
+                        username: widget.username,
+                        profilePic: widget.profilePic,
+                      )
+                    )
+                  );
+                },
+                child: Container(
+                  decoration: BoxDecoration(
+                    color: Colors.grey[300],
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                  height: 80,
+                  child: const Center(
+                  child:  ListTile(
+                    leading: Icon(Icons.person),
+                    title: Text(
+                      "Edit Profile",
+                      style: TextStyle(
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    trailing: Icon(Icons.arrow_forward_ios),
+                  ),)
+                ),
+              ),
+
+              const SizedBox(height: 20,),
+
+              // edit tags
+               GestureDetector(
+                onTap: (){
+                  Navigator.push(
+                    context,
+                    CupertinoPageRoute(
+                      builder: (context) => EditTags(
+                        tags: widget.tags,
+                        origTags: origTags,
+                      )
+                    )
+                  );
+                },
+               child: Container(
+                  decoration: BoxDecoration(
+                    color: Colors.grey[300],
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                  height: 80,
+                  child: const Center(
+                  child:  ListTile(
+                    leading: Icon(Icons.miscellaneous_services),
+                    title: Text(
+                      "Edit Tags",
+                      style: TextStyle(
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    trailing: Icon(Icons.arrow_forward_ios),
+                  ),)
+                ),
+              ),
+
+              const SizedBox(height: 20,),
+
+              // acount is business
+              if(widget.isBusiness)
+                GestureDetector(
+                  onTap: (){
+                    Navigator.push(
+                      context,
+                      CupertinoPageRoute(
+                        builder: (context) => const EditBusinessInfo()
+                      )
+                    );
+                  },
+                child: Container(
+                    decoration: BoxDecoration(
+                      color: Colors.grey[300],
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    height: 80,
+                    child: const Center(
+                    child:  ListTile(
+                      leading: Icon(Icons.business_center),
+                      title: Text(
+                        "Edit Business Information",
+                        style: TextStyle(
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      trailing: Icon(Icons.arrow_forward_ios),
+                    ),)
+                  ),
+                ),
+
+                // acount is not business or a poster
+              if(!widget.isBusiness && widget.tier == "Viewer")
+                GestureDetector(
+                  onTap: (){               
+                    Navigator.push(
+                      context,
+                      CupertinoPageRoute(
+                        builder: (context) => AccountUpgradePage(
+                          tier: widget.tier,
+                          name: widget.name,
+                          email: widget.email,
+                        )
+                      )
+                    );
+                  },
+                  child: Container(
+                   decoration: BoxDecoration(
+                    color: Colors.grey[300],
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                  height: 80,
+                  child: const Center(
+                    child:  ListTile(
+                      leading: Icon(Icons.pending_actions),
+                      title: Text(
+                        "Apply to become a poster",
+                        style: TextStyle(
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      trailing: Icon(Icons.arrow_forward_ios),
+                    ),
+                  ),
+                ),
+              ),
+
+                // account is a poster but not a business
+              if(widget.tier == "Poster" && !widget.isBusiness)
+                GestureDetector(
+                  onTap: (){
+                    Navigator.push(
+                      context,
+                      CupertinoPageRoute(
+                        builder: (context) => AccountUpgradePage(
+                          tier: widget.tier,
+                          name: widget.name,
+                          email: widget.email,
+                        )
+                      )
+                    );
+                  },
+                  child: Container(
+                   decoration: BoxDecoration(
+                    color: Colors.grey[300],
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                  height: 80,
+                  child: const Center(
+                    child:  ListTile(
+                      leading: Icon(Icons.business),
+                      title: Text(
+                        "Apply to become a business",
+                        style: TextStyle(
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      trailing: Icon(Icons.arrow_forward_ios),
+                    ),
+                  ),
+                ),
+              ),
+
+              const SizedBox(height: 20,),
+
+              // delete account
+              GestureDetector(
+                onTap: (){
+                  },
+                child: Container(
+                  decoration: BoxDecoration(
+                    color: Colors.grey[300],
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                  height: 80,
+                  child: const Center(
+                    child:  ListTile(
+                      leading: Icon(Icons.delete),
+                      title: Text(
+                        "Delete Account",
+                        style: TextStyle(
+                          fontWeight: FontWeight.bold,
+                          color: Colors.red,
+                        ),
+                      ),
+                      trailing: Icon(Icons.arrow_forward_ios),
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/flutter/wtc/lib/accountPages/edit_tags.dart
+++ b/flutter/wtc/lib/accountPages/edit_tags.dart
@@ -23,7 +23,8 @@ class _EditTagsState extends State<EditTags> {
 
   User? currentUser = FirebaseAuth.instance.currentUser;
 
-  final items = [
+ final items = [
+    'Construction',
     'News',
     'Weather',
     'Business',
@@ -33,6 +34,7 @@ class _EditTagsState extends State<EditTags> {
     'Food',
     'Government',
     'Job',
+    'Traffic',
     'Volunteer',
     'Pets',
     'Public Resources',

--- a/flutter/wtc/lib/accountPages/edit_tags.dart
+++ b/flutter/wtc/lib/accountPages/edit_tags.dart
@@ -197,6 +197,11 @@ class _EditTagsState extends State<EditTags> {
                               onPressed: ()async{
                                 await updateTags(widget.tags);
                                 await setTags(widget.tags, widget.origTags);
+
+                                setState(() {
+                                  widget.origTags.clear();
+                                  widget.origTags.addAll(widget.tags);
+                                });
                                 
                                 Navigator.of(context).pop();
                                 Navigator.of(context).pop();

--- a/flutter/wtc/lib/app.dart
+++ b/flutter/wtc/lib/app.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:wtc/pages/search_user.dart';
+import 'package:wtc/pages/account_review.dart';
 import 'widgets/navbutton.dart';
 import 'User/user_service.dart';
 import 'pages/home.dart';
@@ -44,6 +45,7 @@ class _NavBars extends State<App> {
   bool showApprovePostsPage = false;
   bool showAboutUsPage = false;
   bool showSearchUsers = false;
+  bool showAccountUpgradePage = false;
   String title = "Welcome To Cheney";
   String prevTitle = "";
   String userTier = "";
@@ -146,6 +148,7 @@ class _NavBars extends State<App> {
                 showApprovePostsPage = false;
                 showAboutUsPage = false;
                 showSearchUsers = false;
+                showAccountUpgradePage = false;
               });
             },
           ),
@@ -164,6 +167,7 @@ class _NavBars extends State<App> {
                 showApprovePostsPage = false;
                 showAboutUsPage = false;
                 showSearchUsers = false;
+                showAccountUpgradePage = false;
               });
             },
           ),
@@ -183,6 +187,7 @@ class _NavBars extends State<App> {
                 showApprovePostsPage = false;
                 showAboutUsPage = false;
                 showSearchUsers = false;
+                showAccountUpgradePage = false;
               });
             },
           ),
@@ -201,6 +206,7 @@ class _NavBars extends State<App> {
                 showApprovePostsPage = false;
                 showAboutUsPage = false;
                 showSearchUsers = false;
+                showAccountUpgradePage = false;
               });
             },
           ),
@@ -220,6 +226,7 @@ class _NavBars extends State<App> {
                 showApprovePostsPage = false;
                 showAboutUsPage = false;
                 showSearchUsers = false;
+                showAccountUpgradePage = false;
               });
             },
           ),
@@ -237,6 +244,7 @@ class _NavBars extends State<App> {
                       showApprovePostsPage = false;
                       showAboutUsPage = false;
                       showSearchUsers = false;
+                      showAccountUpgradePage = false;
                     });
                   },
                 )
@@ -268,6 +276,7 @@ class _NavBars extends State<App> {
                   showJobsPage = false;
                   showAboutUsPage = false;
                   showSearchUsers = false;
+                  showAccountUpgradePage = false;
                 });
               },
             ),
@@ -286,6 +295,25 @@ class _NavBars extends State<App> {
                   showJobsPage = false;
                   showAboutUsPage = false;
                   showSearchUsers = !showSearchUsers;
+                  showAccountUpgradePage = false;
+                });
+              },
+            ),
+          if(userTier == "Admin")
+            ListTile(
+              leading: const Icon(Icons.people_sharp),
+              title: const Text('Upgrade Accounts'),
+              onTap: () {
+                Navigator.pop(context);
+                setState(() {
+                  title = "Upgrade Accounts";
+                  prevTitle = "Upgrade Accounts";
+                  showAccountUpgradePage = !showAccountUpgradePage;
+                  showApprovePostsPage = false;
+                  showVolunteerPage = false;
+                  showNotification = false;
+                  showJobsPage = false;
+                  showAboutUsPage = false;
                 });
               },
             ),
@@ -304,6 +332,7 @@ class _NavBars extends State<App> {
                 showVolunteerPage = false;
                 showApprovePostsPage = false;
                 showSearchUsers = false;
+                showAccountUpgradePage = false;
               });
             },
           ),
@@ -348,7 +377,8 @@ class _NavBars extends State<App> {
           if (showVolunteerPage) const VolunteerPage(),
           if (showApprovePostsPage) const AdminReviewPage(),
           if (showAboutUsPage) const AboutUsPage(),
-          if (showSearchUsers) const SearchUserPage()
+          if (showSearchUsers) const SearchUserPage(),
+          if (showAccountUpgradePage) const AccountReviewPage(),
         ],
       ),
       bottomNavigationBar: NavigationBar(
@@ -366,6 +396,7 @@ class _NavBars extends State<App> {
             showApprovePostsPage = false;
             showAboutUsPage = false;
             showSearchUsers = false;
+            showAccountUpgradePage = false;
           });
         },
         indicatorColor: Colors.white,

--- a/flutter/wtc/lib/auth/auth.dart
+++ b/flutter/wtc/lib/auth/auth.dart
@@ -1,7 +1,7 @@
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:wtc/app.dart';
-import 'package:wtc/pages/login.dart';
+import 'package:wtc/auth/login.dart';
 
 class AuthPage extends StatelessWidget {
   const AuthPage({super.key});

--- a/flutter/wtc/lib/auth/forgot_password.dart
+++ b/flutter/wtc/lib/auth/forgot_password.dart
@@ -36,7 +36,10 @@ class _ForgotPasswordPageState extends State<ForgotPasswordPage> {
           onPressed: (){
             Navigator.pop(context);                   
           }, 
-          icon: const Icon(Icons.arrow_back_ios_new)
+          icon: const Icon(
+            Icons.arrow_back_ios_new,
+            color: Colors.white,
+          )
         ),
         backgroundColor: const Color(0xFF469AB8),
         title: const Text(
@@ -45,6 +48,7 @@ class _ForgotPasswordPageState extends State<ForgotPasswordPage> {
             color: Colors.white
           ),
         ),
+        centerTitle: true,
       ),
       body: Center(
         child: SingleChildScrollView(

--- a/flutter/wtc/lib/auth/getting_started.dart
+++ b/flutter/wtc/lib/auth/getting_started.dart
@@ -25,6 +25,7 @@ class _GettingStartedPageState extends State<GettingStartedPage> {
   File? selectedImage;
 
   final items = [
+    'Construction',
     'News',
     'Weather',
     'Business',
@@ -34,6 +35,7 @@ class _GettingStartedPageState extends State<GettingStartedPage> {
     'Food',
     'Government',
     'Job',
+    'Traffic',
     'Volunteer',
     'Pets',
     'Public Resources',

--- a/flutter/wtc/lib/auth/login.dart
+++ b/flutter/wtc/lib/auth/login.dart
@@ -4,8 +4,8 @@ import 'package:flutter/material.dart';
 import 'package:wtc/components/button.dart';
 import 'package:wtc/components/textfield.dart';
 import 'package:wtc/helper/helper_functions.dart';
-import 'package:wtc/pages/forgot_password.dart';
-import 'package:wtc/pages/register.dart';
+import 'package:wtc/auth/forgot_password.dart';
+import 'package:wtc/auth/register.dart';
 
 class LoginPage extends StatefulWidget{
   const LoginPage({super.key});

--- a/flutter/wtc/lib/auth/register.dart
+++ b/flutter/wtc/lib/auth/register.dart
@@ -5,7 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:wtc/components/button.dart';
 import 'package:wtc/components/textfield.dart';
 import 'package:wtc/helper/helper_functions.dart';
-import 'package:wtc/pages/getting_started.dart';
+import 'package:wtc/auth/welcome_page.dart';
 
 class RegisterPage extends StatefulWidget{
   const RegisterPage({super.key});
@@ -56,10 +56,10 @@ class _RegisterPageState extends State<RegisterPage> {
         createUserDocument(userCredential);
 
         if(context.mounted){
-          Navigator.push(
+          Navigator.pushReplacement(
             context,
             CupertinoPageRoute(
-              builder: (context) => GettingStartedPage(email: emailController.text, uid: userCredential.user!.uid)
+              builder: (context) => IntroPage(email: emailController.text, uid: userCredential.user!.uid)
             )
           );
         }
@@ -81,7 +81,8 @@ class _RegisterPageState extends State<RegisterPage> {
         'name': nameController.text.trim(),
         'tier': "Viewer",
         'pfp': "",
-        'tags': []
+        'tags': [],
+        'isBusiness': false,
       });
     }
   }

--- a/flutter/wtc/lib/auth/welcome_page.dart
+++ b/flutter/wtc/lib/auth/welcome_page.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:smooth_page_indicator/smooth_page_indicator.dart';
+import 'package:wtc/intro_screens/intro_page3.dart';
+import 'package:wtc/intro_screens/intro_page1.dart';
+import 'package:wtc/intro_screens/intro_page2.dart';
+import 'package:wtc/auth/getting_started.dart';
+
+class IntroPage extends StatefulWidget {
+  const IntroPage({super.key, required this.email, required this.uid});
+
+  final String email;
+  final String uid;
+
+  @override
+  State<IntroPage> createState() => _IntroPageState();
+}
+
+class _IntroPageState extends State<IntroPage> {
+
+  PageController _controller = PageController();
+
+  bool _isLastPage = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Stack(
+        children: [
+          PageView(
+            onPageChanged: (index){
+              setState(() {
+                _isLastPage = (index == 2);
+              });
+            },
+            controller: _controller,
+            children: const [
+              IntroPage1(),
+              IntroPage2(),
+              IntroPage3(),
+            ],
+          ),
+
+          Container(
+            alignment: const Alignment(0, 0.75),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+              children: [
+                
+                GestureDetector(
+                  onTap: (){
+                    _controller.jumpToPage(2);
+                  },
+                  child: const Text("Skip")
+                ),
+
+                SmoothPageIndicator(
+                  controller: _controller, 
+                  count: 3
+                ),
+
+                _isLastPage ?
+                GestureDetector(
+                   onTap: (){
+                    Navigator.pushReplacement(
+                      context, 
+                      CupertinoPageRoute(builder: (context) => GettingStartedPage(email: widget.email, uid: widget.uid))
+                    );
+                  },
+                  child: const Text("Done"),
+                )
+                :
+                 GestureDetector(
+                   onTap: (){
+                    _controller.nextPage(
+                      duration: const Duration(milliseconds: 500), 
+                      curve: Curves.easeIn
+                    );
+                  },
+                  child: const Text("Next"),
+                ),
+
+              ],
+            ),
+          )
+        ],
+      ),
+    );
+  }
+}

--- a/flutter/wtc/lib/intro_screens/intro_page1.dart
+++ b/flutter/wtc/lib/intro_screens/intro_page1.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+
+class IntroPage1 extends StatefulWidget {
+  const IntroPage1({super.key});
+
+  @override
+  State<IntroPage1> createState() => _IntroPage1State();
+}
+
+class _IntroPage1State extends State<IntroPage1> {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: Colors.white,
+      alignment: Alignment.center,
+      child: const Text("Intro Page 1"),
+    );
+  }
+}

--- a/flutter/wtc/lib/intro_screens/intro_page2.dart
+++ b/flutter/wtc/lib/intro_screens/intro_page2.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+
+class IntroPage2 extends StatefulWidget {
+  const IntroPage2({super.key});
+
+  @override
+  State<IntroPage2> createState() => _IntroPage2State();
+}
+
+class _IntroPage2State extends State<IntroPage2> {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: Colors.grey.shade300,
+      alignment: Alignment.center,
+      child: const Text(
+        "Intro Page 2",
+        style: TextStyle(
+          color: Colors.black,
+        ),
+      ),
+    );
+  }
+}

--- a/flutter/wtc/lib/intro_screens/intro_page3.dart
+++ b/flutter/wtc/lib/intro_screens/intro_page3.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+
+class IntroPage3 extends StatefulWidget {
+  const IntroPage3({super.key});
+
+  @override
+  State<IntroPage3> createState() => _IntroPage3State();
+}
+
+class _IntroPage3State extends State<IntroPage3> {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: Colors.grey.shade500,
+      alignment: Alignment.center,
+      child: const Text(
+        "Intro Page 3",
+        style: TextStyle(
+          color: Colors.white,
+        ),
+      ),
+    );
+  }
+}

--- a/flutter/wtc/lib/pages/account_review.dart
+++ b/flutter/wtc/lib/pages/account_review.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+
+class AccountReviewPage extends StatefulWidget {
+  const AccountReviewPage({super.key});
+
+  @override
+  State<AccountReviewPage> createState() => _AccountReviewPageState();
+}
+
+class _AccountReviewPageState extends State<AccountReviewPage> {
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(
+        child: Column(
+          children: [
+            Text("Account Review Page")
+          ],
+        )
+      ),
+    );
+  }
+}

--- a/flutter/wtc/lib/pages/accountsettings.dart
+++ b/flutter/wtc/lib/pages/accountsettings.dart
@@ -3,8 +3,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:wtc/pages/edit_profile.dart';
-import 'package:wtc/pages/edit_tags.dart';
+import 'package:wtc/accountPages/edit_settings.dart';
 
 class AccountPage extends StatefulWidget {
   const AccountPage({super.key});
@@ -47,15 +46,14 @@ class _AccountPage extends State<AccountPage> {
             String name = user['name'];
             String email = user['email'];
             String pfp = user['pfp'];
+            String tier = user['tier'];
             var tempTags = user['tags'] as List<dynamic>;
             List<String> tags = [];
+            bool isBusiness = user['isBusiness'];
 
             for(int i = 0; i < tempTags.length; i++){
               tags.add(tempTags[i]);
             }
-
-            List<String> origTags = [];
-            origTags.addAll(tags);
 
             CachedNetworkImage profilePic = CachedNetworkImage(
               imageUrl: pfp,
@@ -73,9 +71,13 @@ class _AccountPage extends State<AccountPage> {
                 child: Column(
                   children: [
                     //pfp
-                    SizedBox(
+                    Container(
                       height: 120,
                       width: 120,
+                      decoration: BoxDecoration(
+                        border: Border.all(color: Colors.black),                     
+                        shape: BoxShape.circle,
+                      ),
                       child: ClipRRect(
                         borderRadius: BorderRadius.circular(200),
                         child: profilePic
@@ -102,59 +104,39 @@ class _AccountPage extends State<AccountPage> {
 
                     const SizedBox(height: 20),
 
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                      children: [
-                        GestureDetector(
-                          onTap: () {
-                            //Navigator.pop(context);
-                            Navigator.push(
-                              context,
-                              CupertinoPageRoute(
-                              builder: (context) => EditProfile(
-                                uid: currentUser!.uid,
+                    // Edit Settings
+                    GestureDetector(
+                      onTap: (){
+                        Navigator.push(
+                          context,
+                          CupertinoPageRoute(
+                            builder: 
+                              (context) => EditSettings(
+                                tier: tier, 
+                                email: email, 
+                                tags: tags, 
+                                isBusiness: isBusiness, 
+                                username: username, 
                                 name: name, 
                                 profilePic: profilePic,
-                                username: username,
-                                )
+                                uid: currentUser!.uid,
                               )
-                            );
-                          },
-                          child: const Text(
-                            "Edit Profile",
-                            style: TextStyle(
-                              fontWeight: FontWeight.bold,
-                              fontSize: 16,
-                            ),
-                            textAlign: TextAlign.right,
-                          ),
+                          )
+                        );
+                      },
+                      child: const Text(
+                        "Edit Settings",
+                        style: TextStyle(
+                          fontWeight: FontWeight.bold,
+                          fontSize: 16,
                         ),
-
-                        //edit tags button
-                        GestureDetector(
-                          onTap: () {
-                            Navigator.push(
-                              context,
-                              CupertinoPageRoute(
-                                builder: (context) => EditTags(tags: tags, origTags: origTags)
-                              )
-                            );
-                          },
-                          child: const Text(
-                            "Edit Tags",
-                            style: TextStyle(
-                              fontWeight: FontWeight.bold,
-                              fontSize: 16,
-                            ),
-                            textAlign: TextAlign.center,
-                          ),
-                        ),
-                      ],
+                        textAlign: TextAlign.center,
+                      ),
                     ),
 
                     const SizedBox(height: 20),
 
-                    // Bio with edit account button
+                    // Bio
                     Container(
                       width: 350,
                       decoration: const BoxDecoration(
@@ -181,8 +163,9 @@ class _AccountPage extends State<AccountPage> {
                       ),
                     ),
 
+             
                     const SizedBox(
-                      height: 10,
+                      height: 25,
                     ),
 
                     //logout

--- a/flutter/wtc/pubspec.yaml
+++ b/flutter/wtc/pubspec.yaml
@@ -47,6 +47,8 @@ dependencies:
   flutter_map: ^6.1.0
   latlong2: ^0.9.1
   cached_network_image: ^3.3.1
+  smooth_page_indicator: ^1.1.0
+  intl_phone_number_input: ^0.7.4
 
 
 dev_dependencies:


### PR DESCRIPTION
## Intro screens
When registering a new account:
- 3 blank pages that you can scroll thru
- Skip and next button work
- On last page, next turns to 'Done' which then takes you to set your tags/ pfp
## Account Page Redesign
- Edit profile/ edit tags replaced with an edit settings button
- pfp has an outline now
### Edit Settings
- Edit profile and edit tags visible for everyone
- Delete button disabled
- If you're a viewer, button to apply to become a poster is displayed
  * Viewers have the option to apply for Poster or business
- If you're a poster, but not a business, a button to apply for a business is displayed
  * No toggle between a business/ poster should show on the application
- If you're a poster AND a business, an edit business button should be displayed
  * edit business page currently just a blank page
- Admins should only see the Edit profile/ Edit tags/ and delete account button
### Account application page
- Should only submit application if Name, Description, and phone number are filled in
  * If applying for a business, address needs to be filled out to submit application
  * Business hours don't have to be filled out for forum to submit 
## Misc
- Account upgrade now on hamburger menu
  * navigates to a blank page that needs to be filled in
- Updated list of tags 
- Moved all account and authentication files into their own folders to avoid clutter in the pages folder

Should be all the changes