### PR TITLE
Admin delete user / edit user tier

### DIFF
--- a/flutter/wtc/lib/pages/search_user.dart
+++ b/flutter/wtc/lib/pages/search_user.dart
@@ -29,6 +29,11 @@ class _SearchUserPageState extends State<SearchUserPage> {
     });
   }
 
+  void _updatePage(void noParam) async {
+    await getAllUsers();
+    filterUsers(_searchController.text);
+  }
+
   void filterUsers(String query) {
     if (query.isEmpty) {
       setState(() {
@@ -76,11 +81,13 @@ class _SearchUserPageState extends State<SearchUserPage> {
             itemCount: filteredUsers.length,
             itemBuilder: (BuildContext context, int index) {
               return SearchUserInfo(
-                  email: filteredUsers[index]['email'] as String,
-                  username: filteredUsers[index]['username'] as String,
-                  name: filteredUsers[index]['name'] as String,
-                  tier: filteredUsers[index]['tier'] as String,
-                  pfp: filteredUsers[index]['pfp'] as String);
+                email: filteredUsers[index]['email'] as String,
+                username: filteredUsers[index]['username'] as String,
+                name: filteredUsers[index]['name'] as String,
+                tier: filteredUsers[index]['tier'] as String,
+                pfp: filteredUsers[index]['pfp'] as String,
+                onUpdatePage: _updatePage,
+              );
             },
             separatorBuilder: (BuildContext context, int index) =>
                 const Divider(),

--- a/flutter/wtc/lib/widgets/post_widgets/post_delete_edit_box.dart
+++ b/flutter/wtc/lib/widgets/post_widgets/post_delete_edit_box.dart
@@ -70,7 +70,6 @@ class PostDeleteEditBox extends StatelessWidget {
                 ),
                 TextButton(
                   onPressed: () async {
-                    //Needs to be changed to do the actual deleting of the post.
                     Navigator.of(context).pop();
                     await _deletePost(post.postId.toString());
                   },

--- a/flutter/wtc/lib/widgets/user_widgets/change_tier_radio_buttons.dart
+++ b/flutter/wtc/lib/widgets/user_widgets/change_tier_radio_buttons.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+
+class ChangeTierRadioButton extends StatefulWidget {
+  const ChangeTierRadioButton(
+      {super.key, required this.currentTier, required this.onValueChanged});
+
+  final String currentTier;
+  final ValueChanged<String> onValueChanged;
+
+  @override
+  State<ChangeTierRadioButton> createState() => _ChangeTierRadioButtonState();
+}
+
+class _ChangeTierRadioButtonState extends State<ChangeTierRadioButton> {
+  late String _selectedValue;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.currentTier == "Viewer") {
+      _selectedValue = "Viewer";
+    } else if (widget.currentTier == "Poster") {
+      _selectedValue = "Poster";
+    } else if (widget.currentTier == "Admin") {
+      _selectedValue = "Admin";
+    }
+  }
+
+  void _handleValueChange(String? value) {
+    setState(() {
+      _selectedValue = value!;
+    });
+    widget.onValueChanged(_selectedValue);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(mainAxisAlignment: MainAxisAlignment.center, children: [
+      ListTile(
+          title: const Text('Viewer'),
+          leading: Radio<String>(
+            value: "Viewer",
+            groupValue: _selectedValue,
+            onChanged: _handleValueChange,
+          )),
+      ListTile(
+          title: const Text('Poster'),
+          leading: Radio<String>(
+            value: "Poster",
+            groupValue: _selectedValue,
+            onChanged: _handleValueChange,
+          )),
+      ListTile(
+          title: const Text('Admin'),
+          leading: Radio<String>(
+            value: "Admin",
+            groupValue: _selectedValue,
+            onChanged: _handleValueChange,
+          )),
+    ]);
+  }
+}

--- a/flutter/wtc/lib/widgets/user_widgets/search_user_delete_edit.dart
+++ b/flutter/wtc/lib/widgets/user_widgets/search_user_delete_edit.dart
@@ -4,9 +4,11 @@ import 'package:wtc/widgets/user_widgets/change_tier_radio_buttons.dart';
 import 'package:wtc/widgets/user_widgets/search_user_info.dart';
 
 class SearchUserDeleteEdit extends StatefulWidget {
-  const SearchUserDeleteEdit({super.key, required this.user});
+  const SearchUserDeleteEdit(
+      {super.key, required this.user, required this.onUpdatePage});
 
   final SearchUserInfo user;
+  final ValueChanged<void> onUpdatePage;
 
   @override
   State<SearchUserDeleteEdit> createState() => _SearchUserDeleteEditState();
@@ -71,6 +73,8 @@ class _SearchUserDeleteEditState extends State<SearchUserDeleteEdit> {
                   onPressed: () async {
                     Navigator.of(context).pop();
                     await _deleteUser(widget.user.email);
+                    void noParam;
+                    widget.onUpdatePage(noParam);
                   },
                   child: const Text("Confirm",
                       style: TextStyle(fontSize: 24, color: Colors.green)),
@@ -111,6 +115,8 @@ class _SearchUserDeleteEditState extends State<SearchUserDeleteEdit> {
                           onPressed: () async {
                             Navigator.of(context).pop();
                             _editUserTier(widget.user.email, newTier);
+                            void noParam;
+                            widget.onUpdatePage(noParam);
                           },
                           child: const Text("Confirm",
                               style:

--- a/flutter/wtc/lib/widgets/user_widgets/search_user_delete_edit.dart
+++ b/flutter/wtc/lib/widgets/user_widgets/search_user_delete_edit.dart
@@ -1,0 +1,141 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+import 'package:wtc/widgets/user_widgets/change_tier_radio_buttons.dart';
+import 'package:wtc/widgets/user_widgets/search_user_info.dart';
+
+class SearchUserDeleteEdit extends StatefulWidget {
+  const SearchUserDeleteEdit({super.key, required this.user});
+
+  final SearchUserInfo user;
+
+  @override
+  State<SearchUserDeleteEdit> createState() => _SearchUserDeleteEditState();
+}
+
+class _SearchUserDeleteEditState extends State<SearchUserDeleteEdit> {
+  late String newTier;
+
+  @override
+  void initState() {
+    super.initState();
+    newTier = widget.user.tier;
+  }
+
+  void _onNewTierChanged(String tier) {
+    setState(() {
+      newTier = tier;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      child: Row(mainAxisAlignment: MainAxisAlignment.center, children: [
+        OutlinedButton(
+            onPressed: () {
+              _showDeleteDialog(context);
+            },
+            child: const Text("Delete User",
+                style: TextStyle(fontSize: 24, color: Colors.red))),
+        const SizedBox(width: 10),
+        OutlinedButton(
+            onPressed: () {
+              _showEditDialog(context);
+            },
+            child: const Text("Edit Tier",
+                style: TextStyle(fontSize: 24, color: Color(0xFF469AB8)))),
+      ]),
+    );
+  }
+
+  void _showDeleteDialog(BuildContext context) {
+    showDialog(
+        context: context,
+        builder: (BuildContext context) {
+          return AlertDialog(
+              actionsAlignment: MainAxisAlignment.center,
+              title: const Text(
+                "Delete User",
+                textAlign: TextAlign.center,
+              ),
+              content: const Text(
+                  "Are you sure you want to delete this users account?"),
+              actions: <Widget>[
+                TextButton(
+                  onPressed: () {
+                    Navigator.of(context).pop();
+                  },
+                  child: const Text("Close", style: TextStyle(fontSize: 24)),
+                ),
+                TextButton(
+                  onPressed: () async {
+                    Navigator.of(context).pop();
+                    await _deleteUser(widget.user.email);
+                  },
+                  child: const Text("Confirm",
+                      style: TextStyle(fontSize: 24, color: Colors.green)),
+                )
+              ]);
+        });
+  }
+
+  void _showEditDialog(BuildContext context) {
+    showDialog(
+        context: context,
+        builder: (BuildContext context) {
+          return AlertDialog(
+              actionsAlignment: MainAxisAlignment.center,
+              title: const Text(
+                "Edit User Tier",
+                textAlign: TextAlign.center,
+              ),
+              content: const Text("Edit this users account tier?"),
+              actions: <Widget>[
+                Column(
+                  children: [
+                    ChangeTierRadioButton(
+                      currentTier: widget.user.tier,
+                      onValueChanged: _onNewTierChanged,
+                    ),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        TextButton(
+                          onPressed: () {
+                            Navigator.of(context).pop();
+                          },
+                          child: const Text("Close",
+                              style: TextStyle(fontSize: 24)),
+                        ),
+                        TextButton(
+                          onPressed: () async {
+                            Navigator.of(context).pop();
+                            _editUserTier(widget.user.email, newTier);
+                          },
+                          child: const Text("Confirm",
+                              style:
+                                  TextStyle(fontSize: 24, color: Colors.green)),
+                        )
+                      ],
+                    )
+                  ],
+                )
+              ]);
+        });
+  }
+
+  Future<void> _deleteUser(String email) async {
+    try {
+      await FirebaseFirestore.instance.collection("users").doc(email).delete();
+    } catch (error) {
+      print("Error deleting post: $error");
+    }
+  }
+
+  Future<void> _editUserTier(String email, String newTier) async {
+    await FirebaseFirestore.instance
+        .collection("users")
+        .doc(email)
+        .update({'tier': newTier});
+  }
+}

--- a/flutter/wtc/lib/widgets/user_widgets/search_user_info.dart
+++ b/flutter/wtc/lib/widgets/user_widgets/search_user_info.dart
@@ -9,13 +9,15 @@ class SearchUserInfo extends StatelessWidget {
       required this.username,
       required this.name,
       required this.tier,
-      required this.pfp});
+      required this.pfp,
+      required this.onUpdatePage});
 
   final String email;
   final String username;
   final String name;
   final String tier;
   final String pfp;
+  final ValueChanged<void> onUpdatePage;
 
   @override
   Widget build(BuildContext context) {
@@ -51,7 +53,10 @@ class SearchUserInfo extends StatelessWidget {
             )
           ],
         ),
-        SearchUserDeleteEdit(user: this),
+        SearchUserDeleteEdit(
+          user: this,
+          onUpdatePage: onUpdatePage,
+        ),
       ],
     );
   }

--- a/flutter/wtc/lib/widgets/user_widgets/search_user_info.dart
+++ b/flutter/wtc/lib/widgets/user_widgets/search_user_info.dart
@@ -1,5 +1,6 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
+import 'package:wtc/widgets/user_widgets/search_user_delete_edit.dart';
 
 class SearchUserInfo extends StatelessWidget {
   const SearchUserInfo(
@@ -18,33 +19,39 @@ class SearchUserInfo extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Row(
+    return Column(
       children: [
-        ClipRRect(
-          borderRadius: BorderRadius.circular(50),
-          child: CachedNetworkImage(
-            imageUrl: pfp,
-            placeholder: (context, url) => const CircularProgressIndicator(),
-            errorWidget: (context, url, error) => const Image(
-                image: AssetImage('images/profile.jpg'),
-                width: 120,
-                height: 120),
-            memCacheHeight: 120,
-            memCacheWidth: 120,
-            fit: BoxFit.cover,
-          ),
-        ),
-        Column(
+        Row(
           children: [
-            Text("Email: $email"),
-            const SizedBox(height: 10),
-            Text("Username: $username"),
-            const SizedBox(height: 10),
-            Text("Name: $name"),
-            const SizedBox(height: 10),
-            Text("Tier: $tier"),
+            ClipRRect(
+              borderRadius: BorderRadius.circular(50),
+              child: CachedNetworkImage(
+                imageUrl: pfp,
+                placeholder: (context, url) =>
+                    const CircularProgressIndicator(),
+                errorWidget: (context, url, error) => const Image(
+                    image: AssetImage('images/profile.jpg'),
+                    width: 120,
+                    height: 120),
+                memCacheHeight: 120,
+                memCacheWidth: 120,
+                fit: BoxFit.cover,
+              ),
+            ),
+            Column(
+              children: [
+                Text("Email: $email"),
+                const SizedBox(height: 10),
+                Text("Username: $username"),
+                const SizedBox(height: 10),
+                Text("Name: $name"),
+                const SizedBox(height: 10),
+                Text("Tier: $tier"),
+              ],
+            )
           ],
-        )
+        ),
+        SearchUserDeleteEdit(user: this),
       ],
     );
   }


### PR DESCRIPTION
- Added 2 new files SearchUserDeleteEdit and ChangeTierRadioButtons

- When an Admin clicks delete they are shown a dialog that asks if they're sure they want to delete the user. If they click "close" the dialog closes and nothing happens. If they click "confirm" the user is successfully deleted and the list updates itself, showing that the user has been deleted.

- When an admin clicks edit tier they are shown another dialog that has radio buttons for the different tiers, with the current tier of the user pre-selected. If they press "close" the dialog closes and nothing happens. If the user clicks "confirm" the user in question will have they're tier updated to which ever tier was selected by the radio buttons. After this point the list refreshes itself and the changes to the user's tier are reflected in the list.

- If an admin performs a search that filters the list and then takes either the delete user or edit user tier action, when the list updates, the filtered list is maintained.