### PR TITLE
email delete bugfix

### DIFF
--- a/flutter/wtc/lib/accountPages/edit_settings.dart
+++ b/flutter/wtc/lib/accountPages/edit_settings.dart
@@ -639,7 +639,6 @@ class _EditSettingsState extends State<EditSettings> {
                                     //await FirebaseAuth.instance.revokeTokenWithAuthorizationCode();
         
                                     await deleteAccount(widget.email, widget.tags, widget.uid);
-                                    FirebaseFirestore.instance.clearPersistence();                                 
                                     Navigator.pushAndRemoveUntil(
                                       context, 
                                       CupertinoPageRoute(
@@ -709,18 +708,16 @@ class _EditSettingsState extends State<EditSettings> {
                                         );
                                       }
                                     );
-                                      await FirebaseAuth.instance.currentUser!
-                                        .reauthenticateWithCredential(
-                                          EmailAuthProvider.credential(
-                                            email: widget.email, 
-                                            password: passwordController.text.trim()
-                                          )
-                                      );
-                                    //print("reauthenticated successfully");
-        
-                                      await deleteAccount(widget.email, widget.tags, widget.uid);
-                                      await FirebaseFirestore.instance.clearPersistence();
-                                      Navigator.pushAndRemoveUntil(
+                                    await FirebaseAuth.instance.currentUser!
+                                      .reauthenticateWithCredential(
+                                        EmailAuthProvider.credential(
+                                          email: widget.email, 
+                                          password: passwordController.text.trim()
+                                        )
+                                    );
+                                    
+                                    await deleteAccount(widget.email, widget.tags, widget.uid);
+                                    Navigator.pushAndRemoveUntil(
                                       context, 
                                       CupertinoPageRoute(
                                         builder: (context) => const AuthPage()


### PR DESCRIPTION
When deleting an account with an email, it should take you back to the login page instead of staying in the spinning circle

* signing up for account sends verification email now as a heads up