### PR TITLE
Homepage scroll down refresh

### DIFF
--- a/flutter/wtc/lib/widgets/post_widgets/post_list.dart
+++ b/flutter/wtc/lib/widgets/post_widgets/post_list.dart
@@ -7,6 +7,7 @@ import 'package:wtc/widgets/job_post/job_post.dart';
 import 'package:wtc/widgets/post_widgets/post.dart';
 import 'package:wtc/widgets/post_widgets/postlist_no_posts.dart';
 import 'package:wtc/widgets/post_widgets/postlist_no_tags.dart';
+import 'package:liquid_pull_to_refresh/liquid_pull_to_refresh.dart';
 
 class PostList extends StatefulWidget {
   const PostList({super.key});
@@ -33,6 +34,8 @@ class _PostListState extends State<PostList> {
     List<String> userTags = userTagsDynamic.cast<String>();
     return userTags;
   }
+
+  Future<void> _testRefresh() async {}
 
   void _refresh() {
     setState(() {
@@ -76,110 +79,115 @@ class _PostListState extends State<PostList> {
                     userTags: userTags, refreshPage: _refresh);
               }
 
-              return ListView.separated(
-                padding: const EdgeInsets.all(8),
-                itemCount: snapshot.data?.docs.length ?? 0,
-                itemBuilder: (BuildContext context, int index) {
-                  var document = snapshot.data?.docs[index];
-                  String type = document?['type'] as String;
-                  String dateCreated = document?['createdAt'] as String;
+              return LiquidPullToRefresh(
+                color: const Color(0xFF469AB8),
+                backgroundColor: const Color(0xffd4bc93),
+                onRefresh: _testRefresh,
+                child: ListView.separated(
+                  padding: const EdgeInsets.all(8),
+                  itemCount: snapshot.data?.docs.length ?? 0,
+                  itemBuilder: (BuildContext context, int index) {
+                    var document = snapshot.data?.docs[index];
+                    String type = document?['type'] as String;
+                    String dateCreated = document?['createdAt'] as String;
 
-                  // Use if-else block to return the correct type of Post for the proper formatting
-                  if (type == "Event") {
-                    var tempTags = document?['tags'] as List<dynamic>;
-                    List<String> postTags = tempTags.cast<String>();
+                    // Use if-else block to return the correct type of Post for the proper formatting
+                    if (type == "Event") {
+                      var tempTags = document?['tags'] as List<dynamic>;
+                      List<String> postTags = tempTags.cast<String>();
 
-                    String dateOfEvent = document?['eventDate'] as String;
-                    String timeOfEvent = document?['eventTime'] as String;
-                    var time = timeOfEvent.split(' ');
-                    int hour = 0;
-                    if (time[1] == "PM") {
-                      if (time[0].split(":")[0] == "12") {
-                        hour = 12;
+                      String dateOfEvent = document?['eventDate'] as String;
+                      String timeOfEvent = document?['eventTime'] as String;
+                      var time = timeOfEvent.split(' ');
+                      int hour = 0;
+                      if (time[1] == "PM") {
+                        if (time[0].split(":")[0] == "12") {
+                          hour = 12;
+                        } else {
+                          hour = int.parse(time[0].split(":")[0]) + 12;
+                        }
                       } else {
-                        hour = int.parse(time[0].split(":")[0]) + 12;
+                        hour = int.parse(time[0].split(":")[0]);
                       }
-                    } else {
-                      hour = int.parse(time[0].split(":")[0]);
-                    }
-                    int minute = int.parse(time[0].split(":")[1]);
+                      int minute = int.parse(time[0].split(":")[1]);
 
-                    return Event(
-                      title: document?['title'] as String,
-                      body: document?['body'] as String,
-                      tags: postTags,
-                      header: document?['header'] as String,
-                      interestCount: document?['interestCount'] as int,
-                      created: DateTime(
-                          int.parse(dateCreated.split("-")[0]),
-                          int.parse(dateCreated.split("-")[1]),
-                          int.parse(dateCreated.split("-")[2])),
-                      postId: Guid(document?['postID'] as String),
-                      userEmail: document?['user'] as String,
-                      date: DateTime(
-                          int.parse(dateOfEvent.split("-")[0]),
-                          int.parse(dateOfEvent.split("-")[1]),
-                          int.parse(dateOfEvent.split("-")[2])),
-                      time: TimeOfDay(hour: hour, minute: minute),
-                      location: document?['address'] as String,
-                      attendingCount: document?['attendingCount'] as int,
-                      maybeCount: document?['maybeCount'] as int,
-                    );
-                  } else if (type == "Job") {
-                    var wage = document?['wage'];
-                    if (wage is int) {
-                      wage = wage.toDouble();
+                      return Event(
+                        title: document?['title'] as String,
+                        body: document?['body'] as String,
+                        tags: postTags,
+                        header: document?['header'] as String,
+                        interestCount: document?['interestCount'] as int,
+                        created: DateTime(
+                            int.parse(dateCreated.split("-")[0]),
+                            int.parse(dateCreated.split("-")[1]),
+                            int.parse(dateCreated.split("-")[2])),
+                        postId: Guid(document?['postID'] as String),
+                        userEmail: document?['user'] as String,
+                        date: DateTime(
+                            int.parse(dateOfEvent.split("-")[0]),
+                            int.parse(dateOfEvent.split("-")[1]),
+                            int.parse(dateOfEvent.split("-")[2])),
+                        time: TimeOfDay(hour: hour, minute: minute),
+                        location: document?['address'] as String,
+                        attendingCount: document?['attendingCount'] as int,
+                        maybeCount: document?['maybeCount'] as int,
+                      );
+                    } else if (type == "Job") {
+                      var wage = document?['wage'];
+                      if (wage is int) {
+                        wage = wage.toDouble();
+                      }
+                      return JobPost(
+                        title: document?['title'] as String,
+                        body: document?['body'] as String,
+                        tags: const ["Job"],
+                        header: document?['header'] as String,
+                        userEmail: document?['user'] as String,
+                        interestCount: document?['interestCount'] as int,
+                        created: DateTime(
+                            int.parse(dateCreated.split("-")[0]),
+                            int.parse(dateCreated.split("-")[1]),
+                            int.parse(dateCreated.split("-")[2])),
+                        postId: Guid(document?['postID'] as String),
+                        wage: wage,
+                        wageType: document?['wageType'] as String,
+                      );
+                    } else if (type == "Volunteer") {
+                      return JobPost(
+                        title: document?['title'] as String,
+                        body: document?['body'] as String,
+                        tags: const ["Volunteer"],
+                        header: document?['header'] as String,
+                        userEmail: document?['user'] as String,
+                        interestCount: document?['interestCount'] as int,
+                        created: DateTime(
+                            int.parse(dateCreated.split("-")[0]),
+                            int.parse(dateCreated.split("-")[1]),
+                            int.parse(dateCreated.split("-")[2])),
+                        postId: Guid(document?['postID'] as String),
+                        volunteer: true,
+                      );
+                    } else {
+                      var tempTags = document?['tags'] as List<dynamic>;
+                      List<String> postTags = tempTags.cast<String>();
+                      return Post(
+                        postId: Guid(document?['postID'] as String),
+                        header: document?['header'] as String,
+                        userEmail: document?['user'] as String,
+                        interestCount: document?['interestCount'] as int,
+                        created: DateTime(
+                            int.parse(dateCreated.split("-")[0]),
+                            int.parse(dateCreated.split("-")[1]),
+                            int.parse(dateCreated.split("-")[2])),
+                        title: document?['title'] as String,
+                        tags: postTags,
+                        body: document?['body'] as String,
+                      );
                     }
-                    return JobPost(
-                      title: document?['title'] as String,
-                      body: document?['body'] as String,
-                      tags: const ["Job"],
-                      header: document?['header'] as String,
-                      userEmail: document?['user'] as String,
-                      interestCount: document?['interestCount'] as int,
-                      created: DateTime(
-                          int.parse(dateCreated.split("-")[0]),
-                          int.parse(dateCreated.split("-")[1]),
-                          int.parse(dateCreated.split("-")[2])),
-                      postId: Guid(document?['postID'] as String),
-                      wage: wage,
-                      wageType: document?['wageType'] as String,
-                    );
-                  } else if (type == "Volunteer") {
-                    return JobPost(
-                      title: document?['title'] as String,
-                      body: document?['body'] as String,
-                      tags: const ["Volunteer"],
-                      header: document?['header'] as String,
-                      userEmail: document?['user'] as String,
-                      interestCount: document?['interestCount'] as int,
-                      created: DateTime(
-                          int.parse(dateCreated.split("-")[0]),
-                          int.parse(dateCreated.split("-")[1]),
-                          int.parse(dateCreated.split("-")[2])),
-                      postId: Guid(document?['postID'] as String),
-                      volunteer: true,
-                    );
-                  } else {
-                    var tempTags = document?['tags'] as List<dynamic>;
-                    List<String> postTags = tempTags.cast<String>();
-                    return Post(
-                      postId: Guid(document?['postID'] as String),
-                      header: document?['header'] as String,
-                      userEmail: document?['user'] as String,
-                      interestCount: document?['interestCount'] as int,
-                      created: DateTime(
-                          int.parse(dateCreated.split("-")[0]),
-                          int.parse(dateCreated.split("-")[1]),
-                          int.parse(dateCreated.split("-")[2])),
-                      title: document?['title'] as String,
-                      tags: postTags,
-                      body: document?['body'] as String,
-                    );
-                  }
-                },
-                separatorBuilder: (BuildContext context, int index) =>
-                    const Divider(),
+                  },
+                  separatorBuilder: (BuildContext context, int index) =>
+                      const Divider(),
+                ),
               );
             },
           );

--- a/flutter/wtc/lib/widgets/post_widgets/post_list.dart
+++ b/flutter/wtc/lib/widgets/post_widgets/post_list.dart
@@ -51,6 +51,7 @@ class _PostListState extends State<PostList> {
   }
 
   Future<void> _refreshPosts() async {
+    await Future.delayed(const Duration(seconds: 2));
     setState(() {
       _postsFuture = _fetchPosts();
     });

--- a/flutter/wtc/pubspec.yaml
+++ b/flutter/wtc/pubspec.yaml
@@ -44,6 +44,7 @@ dependencies:
   cloud_functions: ^4.6.8
   firebase_storage: ^11.6.9
   image_picker: ^1.0.8
+  liquid_pull_to_refresh: ^3.0.1
 
   flutter_map: ^6.1.0
   latlong2: ^0.9.1


### PR DESCRIPTION
## Liquid Pull To Refresh:

- While at the top of the home page if you scroll down a animation will play out as the list of posts refreshes itself from the database.
- The home page is now a static list of posts that becomes refreshed when the user uses the "Pull down to refresh" feature.
- This use of the pull down to refresh will help save on the number of reads the database does by not constantly querying the db every time a post is added to the db.

### How to test:

1. Make sure you can access the app via two devices (either with someone else or on two computers etc.). 
2. On device 1, create a post that has a tag that the currently signed in user has selected.
3. Once the post has been created the new post should NOT automatically pop-up on the screen of device 2.
4. Now use the refresh feature on device 2 and the newly created post should appear at the top of the list.